### PR TITLE
fix(default-theme): missing navigation items and its URLs

### DIFF
--- a/packages/default-theme/src/cms/elements/CmsElementCategoryNavigation.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementCategoryNavigation.vue
@@ -9,7 +9,7 @@
         <SfAccordionItem
           v-for="accordion in navigation"
           :key="accordion.id"
-          :header="accordion.name"
+          :header="accordion.translated.name"
         >
           <template #header="{ header, isOpen, accordionClick }">
             <div class="cms-element-category-navigation__menu-item">
@@ -35,20 +35,20 @@
             <SfList>
               <SfListItem v-for="item in accordion.children" :key="item.id">
                 <nuxt-link
-                  v-if="item.route && item.name"
+                  v-if="item.route && item.translated.name"
                   :to="$routing.getUrl(getCategoryUrl(item))"
                 >
-                  <SfMenuItem :label="item.name" />
+                  <SfMenuItem :label="item.translated.name" />
                 </nuxt-link>
               </SfListItem>
             </SfList>
           </template>
           <template v-else>
             <nuxt-link
-              v-if="accordion.route && accordion.name"
+              v-if="accordion.route && accordion.translated.name"
               :to="$routing.getUrl(getCategoryUrl(accordion))"
             >
-              {{ $t("See") }} {{ accordion.name }}
+              {{ $t("See") }} {{ accordion.translated.name }}
             </nuxt-link>
           </template>
         </SfAccordionItem>
@@ -65,8 +65,10 @@ import {
   SfHeading,
   SfChevron,
 } from "@storefront-ui/vue"
-import { getNavigation } from "@shopware-pwa/shopware-6-client"
-import { useCms } from "@shopware-pwa/composables"
+import { getStoreNavigation } from "@shopware-pwa/shopware-6-client"
+import { useCms, getApplicationContext } from "@shopware-pwa/composables"
+import { ref, computed, onMounted } from "@vue/composition-api"
+
 import SwButton from "@/components/atoms/SwButton"
 import { getCategoryUrl } from "@shopware-pwa/helpers"
 
@@ -86,31 +88,35 @@ export default {
       default: () => ({}),
     },
   },
-  setup(props, { root }) {
-    const { categoryId } = useCms(root)
-
-    return { categoryId, getCategoryUrl }
-  },
-  data() {
-    return {
-      navTitle: "Subcategories",
-      navigationElements: [],
-    }
-  },
-  computed: {
-    navigation() {
-      return this.navigationElements
-    },
-  },
-  async mounted() {
-    const { children } = await getNavigation(
-      {
-        depth: 2,
-        rootNode: this.categoryId,
-      },
-      this.$shopwareApiInstance
+  setup({}, { root }) {
+    const { apiInstance } = getApplicationContext(
+      root,
+      "CmsElementCategoryNavigation"
     )
-    this.navigationElements = children
+    const { categoryId } = useCms(root)
+    const navTitle = ref(root.$t("Subcategories"))
+    const navigationElements = ref([])
+    const navigation = computed(() => navigationElements.value)
+
+    onMounted(async () => {
+      try {
+        const response = await getStoreNavigation(
+          {
+            requestActiveId: categoryId.value,
+            requestRootId: categoryId.value,
+          },
+          apiInstance
+        )
+        navigationElements.value = response
+      } catch (error) {
+        console.warn(
+          "CmsElementCategoryNavigation:onMounted:getStoreNavigation",
+          error
+        )
+      }
+    })
+
+    return { navTitle, navigation, getCategoryUrl }
   },
 }
 </script>

--- a/packages/default-theme/src/locales/de-DE.json
+++ b/packages/default-theme/src/locales/de-DE.json
@@ -197,5 +197,6 @@
   "Share your experiences with other customers.": "Teilen Sie Ihre Erfahrungen mit anderen Kunden.",
   "No comments yet": "Noch keine Kommentare",
   "We can't find what you are looking for. Are you lost?": "Wir können nicht finden, wonach Sie suchen. Bist du verloren",
-  "No subcategories": "Keine Unterkategorien"
+  "No subcategories": "Keine Unterkategorien",
+  "Subcategories": "Unterkategorien"
 }

--- a/packages/default-theme/src/locales/en-GB.json
+++ b/packages/default-theme/src/locales/en-GB.json
@@ -203,5 +203,6 @@
   "Share your experiences with other customers.": "Share your experiences with other customers.",
   "No comments yet": "No comments yet",
   "We can't find what you are looking for. Are you lost?": "We can't find what you are looking for. Are you lost?",
-  "No subcategories": "No subcategories"
+  "No subcategories": "No subcategories",
+  "Subcategories": "Subcategories"
 }

--- a/packages/default-theme/src/locales/it-IT.json
+++ b/packages/default-theme/src/locales/it-IT.json
@@ -202,5 +202,6 @@
   "Share your experiences with other customers.": "Condividi le tue esperienze con altri clienti.",
   "No comments yet": "Ancora nessun commento",
   "We can't find what you are looking for. Are you lost?": "Non riusciamo a trovare quello che stai cercando. Ti sei perso?",
-  "No subcategories": "Nessuna sottocategoria"
+  "No subcategories": "Nessuna sottocategoria",
+  "Subcategories": "Sottocategorie"
 }

--- a/packages/default-theme/src/locales/pl-PL.json
+++ b/packages/default-theme/src/locales/pl-PL.json
@@ -202,5 +202,6 @@
   "Share your experiences with other customers.": "Podziel się swoimi wrażeniami z innymi.",
   "No comments yet": "Nie ma jeszcze żadnych komentarzy",
   "We can't find what you are looking for. Are you lost?": "Nie odnaleźliśmy tego, czego czukasz. Zgubiłeś się?",
-  "No subcategories": "Brak podkategorii"
+  "No subcategories": "Brak podkategorii",
+  "Subcategories": "Podkategorie"
 }


### PR DESCRIPTION
## Changes

- use getStoreNavigation instead of deprecated getNavigation method to fetch the subcategories
- use translated names of navi items
- refactor component for composition api style

<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
