### PR TITLE
refactor(default-theme): add vue extension to component imports

### DIFF
--- a/packages/default-theme/src/cms/elements/CmsElementCategoryNavigation.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementCategoryNavigation.vue
@@ -69,7 +69,7 @@ import { getStoreNavigation } from "@shopware-pwa/shopware-6-client"
 import { useCms, getApplicationContext } from "@shopware-pwa/composables"
 import { ref, computed, onMounted } from "@vue/composition-api"
 
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { getCategoryUrl } from "@shopware-pwa/helpers"
 
 export default {

--- a/packages/default-theme/src/cms/elements/CmsElementCategorySidebarFilter.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementCategorySidebarFilter.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script>
-import SwProductListingFilters from "@/components/SwProductListingFilters"
+import SwProductListingFilters from "@/components/SwProductListingFilters.vue"
 
 export default {
   name: "CmsElementCategorySidebarFilter",

--- a/packages/default-theme/src/cms/elements/CmsElementContactForm.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementContactForm.vue
@@ -146,9 +146,9 @@ import {
   getApplicationContext,
 } from "@shopware-pwa/composables"
 import { computed, ref } from "@vue/composition-api"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { sendContactForm } from "@shopware-pwa/shopware-6-client"
-import SwErrorsList from "@/components/SwErrorsList"
+import SwErrorsList from "@/components/SwErrorsList.vue"
 
 export default {
   name: "CmsElementContactForm",

--- a/packages/default-theme/src/cms/elements/CmsElementImage.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementImage.vue
@@ -26,7 +26,7 @@
 <script>
 import { getCmsLink, getCmsLinkTarget } from "@shopware-pwa/helpers"
 import { SfImage } from "@storefront-ui/vue"
-import SwLink from "@/components/atoms/SwLink"
+import SwLink from "@/components/atoms/SwLink.vue"
 
 export default {
   name: "CmsElementImage",

--- a/packages/default-theme/src/cms/elements/CmsElementImageSlider.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementImageSlider.vue
@@ -23,7 +23,7 @@
 
 <script>
 import { SfHero } from "@storefront-ui/vue"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 
 export default {
   name: "CmsElementImageSlider",

--- a/packages/default-theme/src/cms/elements/CmsElementNesletterForm.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementNesletterForm.vue
@@ -71,12 +71,12 @@
 import { SfInput, SfHeading } from "@storefront-ui/vue"
 import { validationMixin } from "vuelidate"
 import { required, email } from "vuelidate/lib/validators"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { newsletterSubscribe } from "@shopware-pwa/shopware-6-client"
 import { ref } from "@vue/composition-api"
 import { getApplicationContext } from "@shopware-pwa/composables"
 import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
-import SwErrorsList from "@/components/SwErrorsList"
+import SwErrorsList from "@/components/SwErrorsList.vue"
 
 export default {
   name: "CmsElementNewsletterForm",

--- a/packages/default-theme/src/cms/elements/CmsElementProductCard.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementProductCard.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import SwProductCard from "@/components/SwProductCard"
+import SwProductCard from "@/components/SwProductCard.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/cms/elements/CmsElementProductListing.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementProductListing.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import SwProductListing from "@/components/SwProductListing"
+import SwProductListing from "@/components/SwProductListing.vue"
 
 export default {
   name: "CmsElementProductListing",

--- a/packages/default-theme/src/cms/elements/CmsElementProductSlider.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementProductSlider.vue
@@ -12,7 +12,7 @@
 
 <script>
 import { SfSection, SfCarousel } from "@storefront-ui/vue"
-import SwProductCard from "@/components/SwProductCard"
+import SwProductCard from "@/components/SwProductCard.vue"
 
 export default {
   name: "CmsElementProductSlider",

--- a/packages/default-theme/src/cms/elements/CmsElementText.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementText.vue
@@ -1,7 +1,7 @@
 <script>
 // import any extra components here
 import { SfLink } from "@storefront-ui/vue"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { renderHtml, getOptionsFromNode } from "html-to-vue"
 export default {
   name: "CmsElementText",

--- a/packages/default-theme/src/components/SwBottomNavigation.vue
+++ b/packages/default-theme/src/components/SwBottomNavigation.vue
@@ -132,10 +132,10 @@ import {
   SfMenuItem,
 } from "@storefront-ui/vue"
 import { useUIState, useUser, useCart } from "@shopware-pwa/composables"
-import SwBottomMenu from "@/components/SwBottomMenu"
+import SwBottomMenu from "@/components/SwBottomMenu.vue"
 import { PAGE_ACCOUNT } from "@/helpers/pages"
 import { getCategoryUrl } from "@shopware-pwa/helpers"
-import SwBottomMoreActions from "@/components/SwBottomMoreActions"
+import SwBottomMoreActions from "@/components/SwBottomMoreActions.vue"
 
 export default {
   name: "SwBottomNavigation",

--- a/packages/default-theme/src/components/SwCart.vue
+++ b/packages/default-theme/src/components/SwCart.vue
@@ -91,10 +91,10 @@ import {
   getApplicationContext,
 } from "@shopware-pwa/composables"
 import { getProducts } from "@shopware-pwa/shopware-6-client"
-import SwCartProduct from "@/components/SwCartProduct"
-import SwButton from "@/components/atoms/SwButton"
+import SwCartProduct from "@/components/SwCartProduct.vue"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { PAGE_CHECKOUT } from "@/helpers/pages"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 import { computed, onMounted, ref, watch } from "@vue/composition-api"
 
 export default {

--- a/packages/default-theme/src/components/SwErrorsList.vue
+++ b/packages/default-theme/src/components/SwErrorsList.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-import SwAlert from "@/components/atoms/SwAlert"
+import SwAlert from "@/components/atoms/SwAlert.vue"
 
 export default {
   name: "SwErrorsList",

--- a/packages/default-theme/src/components/SwFooter.vue
+++ b/packages/default-theme/src/components/SwFooter.vue
@@ -26,8 +26,8 @@
 </template>
 
 <script>
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwFooterNavigation from "@/components/organisms/SwFooterNavigation"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
+import SwFooterNavigation from "@/components/organisms/SwFooterNavigation.vue"
 
 export default {
   name: "SwFooter",

--- a/packages/default-theme/src/components/SwHeader.vue
+++ b/packages/default-theme/src/components/SwHeader.vue
@@ -32,13 +32,13 @@
 import { SfHeader, SfOverlay } from "@storefront-ui/vue"
 import { useUIState } from "@shopware-pwa/composables"
 
-import SwTopBar from "@/components/SwTopBar"
-import SwLogo from "@/components/SwLogo"
-import SwHeaderIcons from "@/components/SwHeaderIcons"
-import SwTopNavigation from "@/components/SwTopNavigation"
-import SwSearchBar from "@/components/SwSearchBar"
+import SwTopBar from "@/components/SwTopBar.vue"
+import SwLogo from "@/components/SwLogo.vue"
+import SwHeaderIcons from "@/components/SwHeaderIcons.vue"
+import SwTopNavigation from "@/components/SwTopNavigation.vue"
+import SwSearchBar from "@/components/SwSearchBar.vue"
 
-import SwCookieBar from "@/components/gdpr/SwCookieBar"
+import SwCookieBar from "@/components/gdpr/SwCookieBar.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/SwHeaderIcons.vue
+++ b/packages/default-theme/src/components/SwHeaderIcons.vue
@@ -75,8 +75,8 @@ import {
   useWishlist,
 } from "@shopware-pwa/composables"
 import { PAGE_ACCOUNT, PAGE_WISHLIST } from "@/helpers/pages"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwButton from "@/components/atoms/SwButton"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
+import SwButton from "@/components/atoms/SwButton.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/SwLogin.vue
+++ b/packages/default-theme/src/components/SwLogin.vue
@@ -52,9 +52,9 @@ import { SfAlert } from "@storefront-ui/vue"
 import { validationMixin } from "vuelidate"
 import { required, email } from "vuelidate/lib/validators"
 import { useUser, useSessionContext } from "@shopware-pwa/composables"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwButton from "@/components/atoms/SwButton"
-import SwInput from "@/components/atoms/SwInput"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwInput from "@/components/atoms/SwInput.vue"
 
 export default {
   name: "SwLogin",

--- a/packages/default-theme/src/components/SwOrderDetails.vue
+++ b/packages/default-theme/src/components/SwOrderDetails.vue
@@ -110,7 +110,7 @@ import {
 } from "@storefront-ui/vue"
 import { useUser, getApplicationContext } from "@shopware-pwa/composables"
 import { ref, onMounted, computed, watch } from "@vue/composition-api"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 import {
   getOrderPaymentMethodId,
   getOrderShippingMethodId,
@@ -120,13 +120,13 @@ import {
   getPaymentMethodDetails,
   getOrderPaymentUrl,
 } from "@shopware-pwa/shopware-6-client"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { PAGE_ORDER_SUCCESS } from "@/helpers/pages"
-import SwOrderDetailsItem from "@/components/SwOrderDetailsItem"
-import SwPersonalDetails from "@/components/SwPersonalDetails"
-import SwAddress from "@/components/SwAddress"
-import SwCheckoutMethod from "@/components/SwCheckoutMethod"
-import SwTotals from "@/components/SwTotals"
+import SwOrderDetailsItem from "@/components/SwOrderDetailsItem.vue"
+import SwPersonalDetails from "@/components/SwPersonalDetails.vue"
+import SwAddress from "@/components/SwAddress.vue"
+import SwCheckoutMethod from "@/components/SwCheckoutMethod.vue"
+import SwTotals from "@/components/SwTotals.vue"
 
 export default {
   name: "SwOrderDetails",

--- a/packages/default-theme/src/components/SwProductCarousel.vue
+++ b/packages/default-theme/src/components/SwProductCarousel.vue
@@ -23,7 +23,7 @@
 
 <script>
 import { SfSection, SfCarousel } from "@storefront-ui/vue"
-import SwProductCard from "@/components/SwProductCard"
+import SwProductCard from "@/components/SwProductCard.vue"
 
 export default {
   name: "SwProductCarousel",

--- a/packages/default-theme/src/components/SwProductDetails.vue
+++ b/packages/default-theme/src/components/SwProductDetails.vue
@@ -87,12 +87,12 @@ export default {
     SfAlert,
     SfAddToCart,
     SfLoader,
-    SwButton: () => import("@/components/atoms/SwButton"),
-    SwProductHeading: () => import("@/components/SwProductHeading"),
-    SwProductSelect: () => import("@/components/SwProductSelect"),
-    SwProductTabs: () => import("@/components/SwProductTabs"),
-    SwProductColors: () => import("@/components/SwProductColors"),
-    SwPluginSlot: () => import("sw-plugins/SwPluginSlot"),
+    SwButton: () => import("@/components/atoms/SwButton.vue"),
+    SwProductHeading: () => import("@/components/SwProductHeading.vue"),
+    SwProductSelect: () => import("@/components/SwProductSelect.vue"),
+    SwProductTabs: () => import("@/components/SwProductTabs.vue"),
+    SwProductColors: () => import("@/components/SwProductColors.vue"),
+    SwPluginSlot: () => import("sw-plugins/SwPluginSlot.vue"),
   },
   props: {
     product: {

--- a/packages/default-theme/src/components/SwProductHeading.vue
+++ b/packages/default-theme/src/components/SwProductHeading.vue
@@ -61,7 +61,7 @@ import {
 
 import { SfBadge, SfHeading, SfPrice, SfRating } from "@storefront-ui/vue"
 
-import SwTierPrices from "@/components/SwTierPrices"
+import SwTierPrices from "@/components/SwTierPrices.vue"
 
 export default {
   name: "SwProductHeading",

--- a/packages/default-theme/src/components/SwProductListing.vue
+++ b/packages/default-theme/src/components/SwProductListing.vue
@@ -85,8 +85,8 @@
 </template>
 
 <script>
-import SwProductCard from "@/components/SwProductCard"
-import SwProductCardHorizontal from "@/components/SwProductCardHorizontal"
+import SwProductCard from "@/components/SwProductCard.vue"
+import SwProductCardHorizontal from "@/components/SwProductCardHorizontal.vue"
 import { SfPagination, SfHeading, SfLoader } from "@storefront-ui/vue"
 import { useUIState, useListing } from "@shopware-pwa/composables"
 import { watch } from "@vue/composition-api"

--- a/packages/default-theme/src/components/SwProductListingFilters.vue
+++ b/packages/default-theme/src/components/SwProductListingFilters.vue
@@ -108,8 +108,8 @@ import {
 import { computed, ref } from "@vue/composition-api"
 
 import { useUIState, useListing } from "@shopware-pwa/composables"
-import SwButton from "@/components/atoms/SwButton"
-import SwProductListingFilter from "@/components/listing/SwProductListingFilter"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwProductListingFilter from "@/components/listing/SwProductListingFilter.vue"
 
 export default {
   name: "CmsElementCategorySidebarFilter",

--- a/packages/default-theme/src/components/SwProductTabs.vue
+++ b/packages/default-theme/src/components/SwProductTabs.vue
@@ -61,8 +61,8 @@ import {
   SfDivider,
 } from "@storefront-ui/vue"
 import { formatDate } from "@/helpers"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwAddProductReview from "@/components/forms/SwAddProductReview"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
+import SwAddProductReview from "@/components/forms/SwAddProductReview.vue"
 export default {
   name: "SwProductTabs",
   components: {

--- a/packages/default-theme/src/components/SwPromoCode.vue
+++ b/packages/default-theme/src/components/SwPromoCode.vue
@@ -33,9 +33,9 @@
 </template>
 
 <script>
-import SwInput from "@/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput.vue"
 import { SfCircleIcon, SfHeading } from "@storefront-ui/vue"
-import SwPromoCodeItem from "@/components/SwPromoCodeItem"
+import SwPromoCodeItem from "@/components/SwPromoCodeItem.vue"
 import { useCart } from "@shopware-pwa/composables"
 import { computed } from "@vue/composition-api"
 

--- a/packages/default-theme/src/components/SwRegister.vue
+++ b/packages/default-theme/src/components/SwRegister.vue
@@ -150,9 +150,9 @@ import {
   mapSalutations,
   getMessagesFromErrorsArray,
 } from "@shopware-pwa/helpers"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwButton from "@/components/atoms/SwButton"
-import SwInput from "@/components/atoms/SwInput"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwInput from "@/components/atoms/SwInput.vue"
 
 export default {
   name: "SwResetPassword",

--- a/packages/default-theme/src/components/SwResetPassword.vue
+++ b/packages/default-theme/src/components/SwResetPassword.vue
@@ -45,8 +45,8 @@ import { SfAlert, SfHeading } from "@storefront-ui/vue"
 import { validationMixin } from "vuelidate"
 import { required, email } from "vuelidate/lib/validators"
 import { useUser } from "@shopware-pwa/composables"
-import SwButton from "@/components/atoms/SwButton"
-import SwInput from "@/components/atoms/SwInput"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwInput from "@/components/atoms/SwInput.vue"
 
 export default {
   name: "SwResetPassword",

--- a/packages/default-theme/src/components/SwSearchBar.vue
+++ b/packages/default-theme/src/components/SwSearchBar.vue
@@ -32,7 +32,7 @@ import {
   unMapMobileObserver,
 } from "@storefront-ui/vue/src/utilities/mobile-observer"
 import { debounce } from "@shopware-pwa/helpers"
-const SwSuggestSearch = () => import("@/components/SwSuggestSearch")
+const SwSuggestSearch = () => import("@/components/SwSuggestSearch.vue")
 
 export default {
   components: {

--- a/packages/default-theme/src/components/SwSuggestSearch.vue
+++ b/packages/default-theme/src/components/SwSuggestSearch.vue
@@ -57,7 +57,7 @@ import {
   SfPrice,
 } from "@storefront-ui/vue"
 import { clickOutside } from "@storefront-ui/vue/src/utilities/directives"
-import Button from "@/components/atoms/SwButton"
+import Button from "@/components/atoms/SwButton.vue"
 import {
   getProductMainImageUrl,
   getProductRegularPrice,

--- a/packages/default-theme/src/components/SwTopBar.vue
+++ b/packages/default-theme/src/components/SwTopBar.vue
@@ -9,8 +9,8 @@
 
 <script>
 import { SfTopBar } from "@storefront-ui/vue"
-import SwCurrencySwitcher from "@/components/SwCurrencySwitcher"
-import SwLanguageSwitcher from "@/components/SwLanguageSwitcher"
+import SwCurrencySwitcher from "@/components/SwCurrencySwitcher.vue"
+import SwLanguageSwitcher from "@/components/SwLanguageSwitcher.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/SwTopNavigation.vue
+++ b/packages/default-theme/src/components/SwTopNavigation.vue
@@ -54,12 +54,12 @@
 <script>
 import { useNavigation, useUIState } from "@shopware-pwa/composables"
 
-import SwMegaMenu from "@/components/SwMegaMenu"
+import SwMegaMenu from "@/components/SwMegaMenu.vue"
 import { ref, onMounted, watch } from "@vue/composition-api"
 import { getCategoryUrl } from "@shopware-pwa/helpers"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 import { useDomains } from "@/logic"
-import SwTopNavigationShowMore from "@/components/SwTopNavigationShowMore"
+import SwTopNavigationShowMore from "@/components/SwTopNavigationShowMore.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/SwTotals.vue
+++ b/packages/default-theme/src/components/SwTotals.vue
@@ -31,7 +31,7 @@
 <script>
 import { SfProperty, SfHeading } from "@storefront-ui/vue"
 
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 
 export default {
   name: "SwTotals",

--- a/packages/default-theme/src/components/account/orders/Order.vue
+++ b/packages/default-theme/src/components/account/orders/Order.vue
@@ -39,7 +39,7 @@
 </template>
 <script>
 import { formatDate, formatPrice } from "@/helpers"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 
 export default {
   name: "Order",

--- a/packages/default-theme/src/components/checkout/sidebar/SidebarOrderReview.vue
+++ b/packages/default-theme/src/components/checkout/sidebar/SidebarOrderReview.vue
@@ -47,11 +47,11 @@
 </template>
 <script>
 import { SfHeading, SfCircleIcon, SfCharacteristic } from "@storefront-ui/vue"
-import PersonalDetailsSummary from "@/components/checkout/summary/PersonalDetailsSummary"
-import ShippingAddressSummary from "@/components/checkout/summary/ShippingAddressSummary"
-import BillingAddressSummary from "@/components/checkout/summary/BillingAddressSummary"
-import PaymentMethodSummary from "@/components/checkout/summary/PaymentMethodSummary"
-import SwInput from "@/components/atoms/SwInput"
+import PersonalDetailsSummary from "@/components/checkout/summary/PersonalDetailsSummary.vue"
+import ShippingAddressSummary from "@/components/checkout/summary/ShippingAddressSummary.vue"
+import BillingAddressSummary from "@/components/checkout/summary/BillingAddressSummary.vue"
+import PaymentMethodSummary from "@/components/checkout/summary/PaymentMethodSummary.vue"
+import SwInput from "@/components/atoms/SwInput.vue"
 
 export default {
   name: "SidebarOrderReview",

--- a/packages/default-theme/src/components/checkout/sidebar/SidebarOrderSummary.vue
+++ b/packages/default-theme/src/components/checkout/sidebar/SidebarOrderSummary.vue
@@ -47,7 +47,7 @@ import {
   SfCharacteristic,
 } from "@storefront-ui/vue"
 import { useCart } from "@shopware-pwa/composables"
-import SwPromoCode from "@/components/SwPromoCode"
+import SwPromoCode from "@/components/SwPromoCode.vue"
 
 export default {
   name: "SidebarOrderSummary",

--- a/packages/default-theme/src/components/checkout/steps/OrderReviewStep.vue
+++ b/packages/default-theme/src/components/checkout/steps/OrderReviewStep.vue
@@ -40,13 +40,13 @@
 </template>
 
 <script>
-import PersonalDetailsSummary from "@/components/checkout/summary/PersonalDetailsSummary"
-import ShippingAddressSummary from "@/components/checkout/summary/ShippingAddressSummary"
-import BillingAddressSummary from "@/components/checkout/summary/BillingAddressSummary"
-import PaymentMethodSummary from "@/components/checkout/summary/PaymentMethodSummary"
-import OrderItemsTable from "@/components/checkout/summary/OrderItemsTable"
-import TotalsSummary from "@/components/checkout/summary/TotalsSummary"
-import SwCartProduct from "@/components/SwCartProduct"
+import PersonalDetailsSummary from "@/components/checkout/summary/PersonalDetailsSummary.vue"
+import ShippingAddressSummary from "@/components/checkout/summary/ShippingAddressSummary.vue"
+import BillingAddressSummary from "@/components/checkout/summary/BillingAddressSummary.vue"
+import PaymentMethodSummary from "@/components/checkout/summary/PaymentMethodSummary.vue"
+import OrderItemsTable from "@/components/checkout/summary/OrderItemsTable.vue"
+import TotalsSummary from "@/components/checkout/summary/TotalsSummary.vue"
+import SwCartProduct from "@/components/SwCartProduct.vue"
 
 import { SfHeading, SfAccordion } from "@storefront-ui/vue"
 import { useCart } from "@shopware-pwa/composables"

--- a/packages/default-theme/src/components/checkout/steps/PaymentStep.vue
+++ b/packages/default-theme/src/components/checkout/steps/PaymentStep.vue
@@ -45,9 +45,9 @@
           </template>
         </SfRadio>
       </div>
-      <div class="form__action">
+      <div class="sw-form__action">
         <SwButton
-          class="sf-button--full-width form__action-button form__action-button--secondary color-secondary desktop-only sw-form__button"
+          class="sf-button--full-width form__action-button form__action-button--secondary color-secondary sw-form__button"
           @click="$emit('click:back')"
         >
           {{ $t("Go back to Shipping") }}
@@ -58,12 +58,6 @@
           @click="$emit('proceed')"
         >
           {{ $t("Review order") }}
-        </SwButton>
-        <SwButton
-          class="sf-button--full-width sf-button--text form__action-button form__action-button--secondary mobile-only sw-form__button"
-          @click="$emit('click:back')"
-        >
-          {{ $t("Go back to Shipping") }}
         </SwButton>
       </div>
     </div>
@@ -110,7 +104,21 @@ export default {
 </script>
 <style lang="scss" scoped>
 @import "@/assets/scss/forms";
+.sw-form {
+  &__action {
+    width: 100%;
+    margin-top: var(--spacer-xl);
+    display: table;
 
+    button {
+      display: table-cell;
+      width: 100%;
+      @include for-desktop {
+        width: 50%;
+      }
+    }
+  }
+}
 .title {
   --heading-padding: var(--spacer-base) 0;
   @include for-desktop {

--- a/packages/default-theme/src/components/checkout/steps/PaymentStep.vue
+++ b/packages/default-theme/src/components/checkout/steps/PaymentStep.vue
@@ -65,12 +65,12 @@
 </template>
 <script>
 import { SfHeading, SfRadio } from "@storefront-ui/vue"
-import BillingAddressGuestForm from "@/components/checkout/steps/guest/BillingAddressGuestForm"
-import BillingAddressUserForm from "@/components/checkout/steps/user/BillingAddressUserForm"
+import BillingAddressGuestForm from "@/components/checkout/steps/guest/BillingAddressGuestForm.vue"
+import BillingAddressUserForm from "@/components/checkout/steps/user/BillingAddressUserForm.vue"
 import { useCheckout, useSessionContext } from "@shopware-pwa/composables"
 import { onMounted, computed } from "@vue/composition-api"
-import SwButton from "@/components/atoms/SwButton"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 import { simplifyString } from "@/helpers"
 
 export default {

--- a/packages/default-theme/src/components/checkout/steps/PersonalDetailsStep.vue
+++ b/packages/default-theme/src/components/checkout/steps/PersonalDetailsStep.vue
@@ -7,8 +7,8 @@
 <script>
 import { useCheckout } from "@shopware-pwa/composables"
 
-import PersonalDetailsGuestForm from "@/components/checkout/steps/guest/PersonalDetailsGuestForm"
-import PersonalDetailsUserForm from "@/components/checkout/steps/user/PersonalDetailsUserForm"
+import PersonalDetailsGuestForm from "@/components/checkout/steps/guest/PersonalDetailsGuestForm.vue"
+import PersonalDetailsUserForm from "@/components/checkout/steps/user/PersonalDetailsUserForm.vue"
 
 export default {
   name: "PersonalDetailsStep",

--- a/packages/default-theme/src/components/checkout/steps/ShippingStep.vue
+++ b/packages/default-theme/src/components/checkout/steps/ShippingStep.vue
@@ -54,25 +54,19 @@
           </template>
         </SfRadio>
       </div>
-      <div class="form__action">
+      <div class="sw-form__action">
         <SwButton
-          class="form__action-button color-secondary desktop-only"
+          class="sw-form__action-button color-secondary"
           @click="$emit('retreat')"
         >
           {{ $t("Go back to Personal details") }}
         </SwButton>
         <SwButton
-          class="sf-button--full-width form__action-button sw-form__button"
+          class="sw-form__action-button sw-form__button"
           data-cy="continue-to-payment"
           @click="$emit('proceed')"
         >
           {{ $t("Continue to payment") }}
-        </SwButton>
-        <SwButton
-          class="sf-button--full-width sf-button--text form__action-button form__action-button--secondary mobile-only sw-form__button"
-          @click="$emit('retreat')"
-        >
-          {{ $t("Go back to Personal details") }}
         </SwButton>
       </div>
     </div>
@@ -131,6 +125,20 @@ export default {
 </script>
 <style lang="scss" scoped>
 @import "@/assets/scss/forms";
+
+.sw-form {
+  &__action {
+    display: table;
+
+    button {
+      display: table-cell;
+      width: 100%;
+      @include for-desktop {
+        width: 50%;
+      }
+    }
+  }
+}
 
 .title {
   --heading-padding: var(--spacer-base) 0;

--- a/packages/default-theme/src/components/checkout/steps/ShippingStep.vue
+++ b/packages/default-theme/src/components/checkout/steps/ShippingStep.vue
@@ -75,16 +75,16 @@
 <script>
 import { SfHeading, SfRadio } from "@storefront-ui/vue"
 import { computed, onMounted } from "@vue/composition-api"
-import ShippingAddressGuestForm from "@/components/checkout/steps/guest/ShippingAddressGuestForm"
-import ShippingAddressUserForm from "@/components/checkout/steps/user/ShippingAddressUserForm"
+import ShippingAddressGuestForm from "@/components/checkout/steps/guest/ShippingAddressGuestForm.vue"
+import ShippingAddressUserForm from "@/components/checkout/steps/user/ShippingAddressUserForm.vue"
 import {
   useCheckout,
   useSessionContext,
   useCart,
 } from "@shopware-pwa/composables"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { simplifyString } from "@/helpers"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 
 export default {
   name: "ShippingStep",

--- a/packages/default-theme/src/components/checkout/steps/guest/BillingAddressGuestForm.vue
+++ b/packages/default-theme/src/components/checkout/steps/guest/BillingAddressGuestForm.vue
@@ -115,7 +115,7 @@ import {
   usePaymentStepValidationRules,
 } from "@/logic/checkout/usePaymentStep"
 import { useCountries, useCountry } from "@shopware-pwa/composables"
-import SwInput from "@/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput.vue"
 
 export default {
   name: "BillingAddressGuestForm",

--- a/packages/default-theme/src/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
+++ b/packages/default-theme/src/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
@@ -106,9 +106,9 @@
 </template>
 <script>
 import { SfCheckbox, SfHeading, SfCharacteristic } from "@storefront-ui/vue"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwButton from "@/components/atoms/SwButton"
-import SwInput from "@/components/atoms/SwInput"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwInput from "@/components/atoms/SwInput.vue"
 
 import { validationMixin } from "vuelidate"
 import {
@@ -132,7 +132,7 @@ import {
   usePersonalDetailsStep,
   usePersonalDetailsStepValidationRules,
 } from "@/logic/checkout/usePersonalDetailsStep"
-import SwErrorsList from "@/components/SwErrorsList"
+import SwErrorsList from "@/components/SwErrorsList.vue"
 
 export default {
   name: "PersonalDetailsGuestForm",

--- a/packages/default-theme/src/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
+++ b/packages/default-theme/src/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
@@ -86,24 +86,19 @@
           class="form__element"
         />
       </transition>
-      <div class="form__action">
+      <div class="sw-form__action">
         <SwButton
-          class="sf-button--full-width form__action-button form__action-button--secondary color-secondary desktop-only sw-form__button"
+          class="form__action-button color-secondary sw-form__button"
           data-cy="go-back-to-shop-button"
         >
           {{ $t("Go Back to shop") }}
         </SwButton>
         <SwButton
-          class="sf-button--full-width form__action-button sw-form__button"
+          class="form__action-button sw-form__button"
           data-cy="continue-to-shipping-button"
           @click="toShipping"
         >
           {{ $t("Continue to shipping") }}
-        </SwButton>
-        <SwButton
-          class="sf-button--full-width sf-button--text form__action-button form__action-button--secondary mobile-only sw-form__button"
-        >
-          {{ $t("Go Back to shop") }}
         </SwButton>
       </div>
     </div>
@@ -415,11 +410,23 @@ export default {
   }
 }
 
-.form__action {
-  margin: var(--spacer-sm) 0;
+.sw-form {
+  &__action {
+    width: 100%;
+    margin-top: var(--spacer-xl);
+    display: table;
 
-  .sf-button + .sf-button {
-    margin-top: var(--spacer-sm);
+    button {
+      display: table-cell;
+      width: 100%;
+      @include for-desktop {
+        width: 50%;
+      }
+
+      &:last-child {
+        margin-top: var(--spacer-base);
+      }
+    }
   }
 }
 </style>

--- a/packages/default-theme/src/components/checkout/steps/guest/ShippingAddressGuestForm.vue
+++ b/packages/default-theme/src/components/checkout/steps/guest/ShippingAddressGuestForm.vue
@@ -111,7 +111,7 @@ import {
   useCountry,
 } from "@shopware-pwa/composables"
 import { computed } from "@vue/composition-api"
-import SwInput from "@/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput.vue"
 
 export default {
   name: "ShippingAddressGuestForm",

--- a/packages/default-theme/src/components/checkout/steps/user/BillingAddressUserForm.vue
+++ b/packages/default-theme/src/components/checkout/steps/user/BillingAddressUserForm.vue
@@ -46,7 +46,7 @@
 <script>
 import { SfList, SfRadio, SfCheckbox } from "@storefront-ui/vue"
 import { useSessionContext, useUser } from "@shopware-pwa/composables"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { ref, watch } from "@vue/composition-api"
 
 export default {

--- a/packages/default-theme/src/components/checkout/steps/user/PersonalDetailsUserForm.vue
+++ b/packages/default-theme/src/components/checkout/steps/user/PersonalDetailsUserForm.vue
@@ -19,8 +19,8 @@
 </template>
 <script>
 import { SfHeading } from "@storefront-ui/vue"
-import SwPersonalInfo from "@/components/forms/SwPersonalInfo"
-import SwButton from "@/components/atoms/SwButton"
+import SwPersonalInfo from "@/components/forms/SwPersonalInfo.vue"
+import SwButton from "@/components/atoms/SwButton.vue"
 
 export default {
   name: "ShippingAddressUserForm",

--- a/packages/default-theme/src/components/checkout/steps/user/PersonalDetailsUserForm.vue
+++ b/packages/default-theme/src/components/checkout/steps/user/PersonalDetailsUserForm.vue
@@ -10,7 +10,7 @@
       </template>
     </SwPersonalInfo>
     <SwButton
-      class="personal-details-user-form__proceed"
+      class="personal-details-user-form__proceed sf-button--full-width"
       @click="$emit('proceed')"
     >
       {{ $t("Continue to shipping") }}

--- a/packages/default-theme/src/components/checkout/steps/user/ShippingAddressUserForm.vue
+++ b/packages/default-theme/src/components/checkout/steps/user/ShippingAddressUserForm.vue
@@ -51,7 +51,7 @@
 <script>
 import { SfList, SfRadio, SfCheckbox, SfModal } from "@storefront-ui/vue"
 import { useSessionContext, useUser } from "@shopware-pwa/composables"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { ref, watch } from "@vue/composition-api"
 import SwAddressForm from "@/components/forms/SwAddressForm.vue"
 

--- a/packages/default-theme/src/components/checkout/summary/BillingAddressSummary.vue
+++ b/packages/default-theme/src/components/checkout/summary/BillingAddressSummary.vue
@@ -12,8 +12,8 @@
 </template>
 <script>
 import { useCheckout } from "@shopware-pwa/composables"
-import SwAddress from "@/components/SwAddress"
-import SwButton from "@/components/atoms/SwButton"
+import SwAddress from "@/components/SwAddress.vue"
+import SwButton from "@/components/atoms/SwButton.vue"
 
 export default {
   name: "BillingAddressSummary",

--- a/packages/default-theme/src/components/checkout/summary/OrderItemsTable.vue
+++ b/packages/default-theme/src/components/checkout/summary/OrderItemsTable.vue
@@ -19,7 +19,7 @@
 </template>
 <script>
 import { useCart } from "@shopware-pwa/composables"
-import OrderItem from "@/components/checkout/summary/OrderItem"
+import OrderItem from "@/components/checkout/summary/OrderItem.vue"
 
 import {
   SfTable,

--- a/packages/default-theme/src/components/checkout/summary/PaymentMethodSummary.vue
+++ b/packages/default-theme/src/components/checkout/summary/PaymentMethodSummary.vue
@@ -11,10 +11,10 @@
   </SwCheckoutMethod>
 </template>
 <script>
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { useSessionContext } from "@shopware-pwa/composables"
 import { computed } from "@vue/composition-api"
-import SwCheckoutMethod from "@/components/SwCheckoutMethod"
+import SwCheckoutMethod from "@/components/SwCheckoutMethod.vue"
 export default {
   name: "PaymentMethodSummary",
   components: {

--- a/packages/default-theme/src/components/checkout/summary/PersonalDetailsSummary.vue
+++ b/packages/default-theme/src/components/checkout/summary/PersonalDetailsSummary.vue
@@ -11,12 +11,12 @@
   </SwPersonalDetails>
 </template>
 <script>
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { usePersonalDetailsStep } from "@/logic/checkout/usePersonalDetailsStep"
 import { CHECKOUT_STEPS } from "@/logic/checkout"
 import { useCheckout, useUser } from "@shopware-pwa/composables"
 import { computed } from "@vue/composition-api"
-import SwPersonalDetails from "@/components/SwPersonalDetails"
+import SwPersonalDetails from "@/components/SwPersonalDetails.vue"
 
 export default {
   name: "PersonalDetailsSummary",

--- a/packages/default-theme/src/components/checkout/summary/ShippingAddressSummary.vue
+++ b/packages/default-theme/src/components/checkout/summary/ShippingAddressSummary.vue
@@ -19,10 +19,10 @@
   </SwAddress>
 </template>
 <script>
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { useSessionContext, useCheckout } from "@shopware-pwa/composables"
-import SwAddress from "@/components/SwAddress"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
+import SwAddress from "@/components/SwAddress.vue"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 import { simplifyString } from "@/helpers"
 
 export default {

--- a/packages/default-theme/src/components/checkout/summary/TotalsSummary.vue
+++ b/packages/default-theme/src/components/checkout/summary/TotalsSummary.vue
@@ -11,7 +11,7 @@
     </div>
     <div class="summary__action">
       <SwButton
-        class="sf-button--full-width summary__action-button summary__action-button--secondary color-secondary desktop-only"
+        class="sf-button--full-width summary__action-button summary__action-button--secondary color-secondary sw-form__button"
         data-cy="go-back-to-payment"
         @click="$emit('click:back')"
       >
@@ -19,17 +19,11 @@
       </SwButton>
       <SwButton
         :disabled="!cartItems.length"
-        class="sf-button--full-width summary__action-button"
+        class="sf-button--full-width summary__action-button sw-form__button"
         data-cy="place-my-order"
         @click="$emit('proceed')"
       >
         {{ $t("Place my order") }}
-      </SwButton>
-      <SwButton
-        class="sf-button--full-width sf-button--text summary__action-button summary__action-button--secondary mobile-only"
-        @click="$emit('click:back')"
-      >
-        {{ $t("Go back to Payment") }}
       </SwButton>
     </div>
   </div>
@@ -112,21 +106,23 @@ export default {
   }
   &__action {
     padding: var(--spacer-base);
-    flex: 0 0 100%;
+    width: 90%;
     margin: var(--spacer-base) 0 0 0;
-    @include for-desktop {
-      display: flex;
-    }
-  }
-  &__action-button {
-    --button-height: 3.25rem;
-    @include for-desktop {
-      --button-font-weight: var(--font-normal);
-      &:first-child {
-        margin: 0 var(--spacer-lg) 0 0;
+    display: table;
+
+    button {
+      display: table-cell;
+      width: 100%;
+      @include for-desktop {
+        width: 50%;
+      }
+
+      &:last-child {
+        margin-top: var(--spacer-base);
       }
     }
   }
+
   &__property {
     margin: 0 0 var(--spacer-sm) 0;
     --property-value-font-weight: var(--font-semibold);

--- a/packages/default-theme/src/components/checkout/summary/TotalsSummary.vue
+++ b/packages/default-theme/src/components/checkout/summary/TotalsSummary.vue
@@ -30,8 +30,7 @@
 </template>
 <script>
 import { useCart } from "@shopware-pwa/composables"
-import SwTotals from "@/components/SwTotals"
-import helpers from "@/helpers"
+import SwTotals from "@/components/SwTotals.vue"
 
 import {
   SfProperty,
@@ -39,7 +38,7 @@ import {
   SfHeading,
   SfNotification,
 } from "@storefront-ui/vue"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 
 export default {
   name: "TotalsSummary",

--- a/packages/default-theme/src/components/forms/SwAddProductReview.vue
+++ b/packages/default-theme/src/components/forms/SwAddProductReview.vue
@@ -66,9 +66,9 @@
 import { SfHeading, SfDivider } from "@storefront-ui/vue"
 import { addProductReview } from "@shopware-pwa/shopware-6-client"
 import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
-import SwButton from "@/components/atoms/SwButton"
-import SwInput from "@/components/atoms/SwInput"
-import SwErrorsList from "@/components/SwErrorsList"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwInput from "@/components/atoms/SwInput.vue"
+import SwErrorsList from "@/components/SwErrorsList.vue"
 import { ref, computed } from "@vue/composition-api"
 import {
   useUser,

--- a/packages/default-theme/src/components/forms/SwAddressForm.vue
+++ b/packages/default-theme/src/components/forms/SwAddressForm.vue
@@ -151,9 +151,9 @@ import {
   mapSalutations,
   getMessagesFromErrorsArray,
 } from "@shopware-pwa/helpers"
-import SwButton from "@/components/atoms/SwButton"
-import SwInput from "@/components/atoms/SwInput"
-import SwErrorsList from "@/components/SwErrorsList"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwInput from "@/components/atoms/SwInput.vue"
+import SwErrorsList from "@/components/SwErrorsList.vue"
 
 export default {
   name: "SwAddressForm",

--- a/packages/default-theme/src/components/forms/SwPassword.vue
+++ b/packages/default-theme/src/components/forms/SwPassword.vue
@@ -72,9 +72,9 @@ import { required, minLength, sameAs } from "vuelidate/lib/validators"
 import { computed } from "@vue/composition-api"
 import { useUser } from "@shopware-pwa/composables"
 import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
-import SwButton from "@/components/atoms/SwButton"
-import SwInput from "@/components/atoms/SwInput"
-import SwErrorsList from "@/components/SwErrorsList"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwInput from "@/components/atoms/SwInput.vue"
+import SwErrorsList from "@/components/SwErrorsList.vue"
 
 export default {
   name: "SwPassword",

--- a/packages/default-theme/src/components/forms/SwPersonalInfo.vue
+++ b/packages/default-theme/src/components/forms/SwPersonalInfo.vue
@@ -101,9 +101,9 @@ import {
 import { SfIcon } from "@storefront-ui/vue"
 import { useUser } from "@shopware-pwa/composables"
 import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
-import SwButton from "@/components/atoms/SwButton"
-import SwInput from "@/components/atoms/SwInput"
-import SwErrorsList from "@/components/SwErrorsList"
+import SwButton from "@/components/atoms/SwButton.vue"
+import SwInput from "@/components/atoms/SwInput.vue"
+import SwErrorsList from "@/components/SwErrorsList.vue"
 
 export default {
   name: "SwPersonalInfo",

--- a/packages/default-theme/src/components/gdpr/SwCookieBar.vue
+++ b/packages/default-theme/src/components/gdpr/SwCookieBar.vue
@@ -15,8 +15,9 @@
 
 <script>
 import { SfTopBar } from "@storefront-ui/vue"
-import SwButton from "@/components/atoms/SwButton"
-const SwCookieBarContent = () => import("@/components/gdpr/SwCookieBarContent")
+import SwButton from "@/components/atoms/SwButton.vue"
+const SwCookieBarContent = () =>
+  import("@/components/gdpr/SwCookieBarContent.vue")
 
 export default {
   name: "SwCookieBar",

--- a/packages/default-theme/src/components/listing/SwProductListingFilter.vue
+++ b/packages/default-theme/src/components/listing/SwProductListingFilter.vue
@@ -14,7 +14,7 @@
 
 <script>
 import { SfFilter } from "@storefront-ui/vue"
-import NoFilterFound from "@/components/listing/NoFilterFound"
+import NoFilterFound from "@/components/listing/NoFilterFound.vue"
 
 export default {
   name: "SwProductListingFilter",
@@ -44,7 +44,8 @@ export default {
       try {
         return () => ({
           component: import(
-            "@/components/listing/types/" + this.filter.label.toLowerCase()
+            "@/components/listing/types/" +
+              this.filter.label.toLowerCase(".vue")
           ),
           error: NoFilterFound,
         })

--- a/packages/default-theme/src/components/listing/types/content.vue
+++ b/packages/default-theme/src/components/listing/types/content.vue
@@ -2,7 +2,7 @@
   <entity v-bind="{ ...$props, ...$attrs }" v-on="$listeners" />
 </template>
 <script>
-import Entity from "@/components/listing/types/entity"
+import Entity from "@/components/listing/types/entity.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/listing/types/fabric.vue
+++ b/packages/default-theme/src/components/listing/types/fabric.vue
@@ -2,7 +2,7 @@
   <entity v-bind="{ ...$props, ...$attrs }" v-on="$listeners" />
 </template>
 <script>
-import Entity from "@/components/listing/types/entity"
+import Entity from "@/components/listing/types/entity.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/listing/types/length.vue
+++ b/packages/default-theme/src/components/listing/types/length.vue
@@ -2,7 +2,7 @@
   <entity v-bind="{ ...$props, ...$attrs }" v-on="$listeners" />
 </template>
 <script>
-import Entity from "@/components/listing/types/entity"
+import Entity from "@/components/listing/types/entity.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/listing/types/manufacturer.vue
+++ b/packages/default-theme/src/components/listing/types/manufacturer.vue
@@ -2,7 +2,7 @@
   <entity v-bind="{ ...$props, ...$attrs }" v-on="$listeners" />
 </template>
 <script>
-import Entity from "@/components/listing/types/entity"
+import Entity from "@/components/listing/types/entity.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/listing/types/max.vue
+++ b/packages/default-theme/src/components/listing/types/max.vue
@@ -13,8 +13,8 @@
 import { computed, ref } from "@vue/composition-api"
 
 const maxMap = {
-  "shipping-free": () => import(`@/components/listing/types/shipping-free.vue`),.vue"
-  rating: () => import(`@/components/listing/types/rating.vue`),.vue"
+  "shipping-free": () => import(`@/components/listing/types/shipping-free.vue`),
+  rating: () => import(`@/components/listing/types/rating.vue`),
 }
 
 export default {

--- a/packages/default-theme/src/components/listing/types/max.vue
+++ b/packages/default-theme/src/components/listing/types/max.vue
@@ -13,8 +13,8 @@
 import { computed, ref } from "@vue/composition-api"
 
 const maxMap = {
-  "shipping-free": () => import(`@/components/listing/types/shipping-free.vue`),
-  rating: () => import(`@/components/listing/types/rating.vue`),
+  "shipping-free": () => import(`@/components/listing/types/shipping-free.vue`),.vue"
+  rating: () => import(`@/components/listing/types/rating.vue`),.vue"
 }
 
 export default {

--- a/packages/default-theme/src/components/listing/types/price.vue
+++ b/packages/default-theme/src/components/listing/types/price.vue
@@ -2,7 +2,7 @@
   <Range v-bind="{ ...$props, ...$attrs }" v-on="$listeners" />
 </template>
 <script>
-import Range from "@/components/listing/types/range"
+import Range from "@/components/listing/types/range.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/listing/types/range.vue
+++ b/packages/default-theme/src/components/listing/types/range.vue
@@ -25,7 +25,7 @@
 import { computed, ref } from "@vue/composition-api"
 
 import { SfFilter, SfHeading } from "@storefront-ui/vue"
-import SwInput from "@/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput.vue"
 import { validationMixin } from "vuelidate"
 import { required, email } from "vuelidate/lib/validators"
 

--- a/packages/default-theme/src/components/listing/types/rating.vue
+++ b/packages/default-theme/src/components/listing/types/rating.vue
@@ -14,7 +14,7 @@
 <script>
 import { computed, ref } from "@vue/composition-api"
 import { SfRating, SfIcon, SfHeading } from "@storefront-ui/vue"
-import SwRating from "@/components/atoms/SwRating"
+import SwRating from "@/components/atoms/SwRating.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/listing/types/shipping-free.vue
+++ b/packages/default-theme/src/components/listing/types/shipping-free.vue
@@ -17,7 +17,7 @@
 import { computed, ref } from "@vue/composition-api"
 
 import { SfFilter, SfCheckbox, SfHeading } from "@storefront-ui/vue"
-import SwInput from "@/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput.vue"
 
 export default {
   name: "SwFilterShippingFree",

--- a/packages/default-theme/src/components/listing/types/size.vue
+++ b/packages/default-theme/src/components/listing/types/size.vue
@@ -2,7 +2,7 @@
   <entity v-bind="{ ...$props, ...$attrs }" v-on="$listeners" />
 </template>
 <script>
-import Entity from "@/components/listing/types/entity"
+import Entity from "@/components/listing/types/entity.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/listing/types/textile.vue
+++ b/packages/default-theme/src/components/listing/types/textile.vue
@@ -2,7 +2,7 @@
   <entity v-bind="{ ...$props, ...$attrs }" v-on="$listeners" />
 </template>
 <script>
-import Entity from "@/components/listing/types/entity"
+import Entity from "@/components/listing/types/entity.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/listing/types/tone.vue
+++ b/packages/default-theme/src/components/listing/types/tone.vue
@@ -2,7 +2,7 @@
   <entity v-bind="{ ...$props, ...$attrs }" v-on="$listeners" />
 </template>
 <script>
-import Entity from "@/components/listing/types/entity"
+import Entity from "@/components/listing/types/entity.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/listing/types/width.vue
+++ b/packages/default-theme/src/components/listing/types/width.vue
@@ -2,7 +2,7 @@
   <entity v-bind="{ ...$props, ...$attrs }" v-on="$listeners" />
 </template>
 <script>
-import Entity from "@/components/listing/types/entity"
+import Entity from "@/components/listing/types/entity.vue"
 
 export default {
   components: {

--- a/packages/default-theme/src/components/modals/SwLoginModal.vue
+++ b/packages/default-theme/src/components/modals/SwLoginModal.vue
@@ -62,10 +62,10 @@
 <script>
 import { SfHeading, SfModal, SfAlert } from "@storefront-ui/vue"
 import { useUser, useUIState } from "@shopware-pwa/composables"
-import SwLogin from "@/components/SwLogin"
-import SwButton from "@/components/atoms/SwButton"
-const SwRegister = () => import("@/components/SwRegister")
-const SwResetPassword = () => import("@/components/SwResetPassword")
+import SwLogin from "@/components/SwLogin.vue"
+import SwButton from "@/components/atoms/SwButton.vue"
+const SwRegister = () => import("@/components/SwRegister.vue")
+const SwResetPassword = () => import("@/components/SwResetPassword.vue")
 
 export default {
   name: "SwLoginModal",

--- a/packages/default-theme/src/components/views/CategoryView.vue
+++ b/packages/default-theme/src/components/views/CategoryView.vue
@@ -4,7 +4,7 @@
   </div>
 </template>
 <script>
-import CmsPage from "sw-cms/CmsPage.vue"
+import CmsPage from "sw-cms/CmsPage"
 
 export default {
   name: "CategoryView",

--- a/packages/default-theme/src/components/views/CategoryView.vue
+++ b/packages/default-theme/src/components/views/CategoryView.vue
@@ -4,7 +4,7 @@
   </div>
 </template>
 <script>
-import CmsPage from "sw-cms/CmsPage"
+import CmsPage from "sw-cms/CmsPage.vue"
 
 export default {
   name: "CategoryView",

--- a/packages/default-theme/src/components/views/ProductView.vue
+++ b/packages/default-theme/src/components/views/ProductView.vue
@@ -63,12 +63,12 @@
 <script>
 import { SfImage, SfSection, SfTabs } from "@storefront-ui/vue"
 import { useProduct, useUser, useUIState } from "@shopware-pwa/composables"
-import SwGoBackArrow from "@/components/atoms/SwGoBackArrow"
-import SwProductGallery from "@/components/SwProductGallery"
-import SwProductDetails from "@/components/SwProductDetails"
-import SwProductCarousel from "@/components/SwProductCarousel"
-import SwProductAdvertisement from "@/components/SwProductAdvertisement"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
+import SwGoBackArrow from "@/components/atoms/SwGoBackArrow.vue"
+import SwProductGallery from "@/components/SwProductGallery.vue"
+import SwProductDetails from "@/components/SwProductDetails.vue"
+import SwProductCarousel from "@/components/SwProductCarousel.vue"
+import SwProductAdvertisement from "@/components/SwProductAdvertisement.vue"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 import { computed, onMounted, ref } from "@vue/composition-api"
 
 export default {

--- a/packages/default-theme/src/layouts/default.vue
+++ b/packages/default-theme/src/layouts/default.vue
@@ -32,16 +32,16 @@
 
 <script>
 import { SfBreadcrumbs } from "@storefront-ui/vue"
-import SwHeader from "@/components/SwHeader"
-import SwBottomNavigation from "@/components/SwBottomNavigation"
-import SwFooter from "@/components/SwFooter"
-import SwPluginSlot from "sw-plugins/SwPluginSlot"
+import SwHeader from "@/components/SwHeader.vue"
+import SwBottomNavigation from "@/components/SwBottomNavigation.vue"
+import SwFooter from "@/components/SwFooter.vue"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 import { useCms, useUIState } from "@shopware-pwa/composables"
 import { computed, ref, watchEffect } from "@vue/composition-api"
-import SwLoginModal from "@/components/modals/SwLoginModal"
-import SwNotifications from "@/components/SwNotifications"
-import SwOfflineMode from "@/components/SwOfflineMode"
-const SwCart = () => import("@/components/SwCart")
+import SwLoginModal from "@/components/modals/SwLoginModal.vue"
+import SwNotifications from "@/components/SwNotifications.vue"
+import SwOfflineMode from "@/components/SwOfflineMode.vue"
+const SwCart = () => import("@/components/SwCart.vue")
 
 export default {
   components: {

--- a/packages/default-theme/src/layouts/error.vue
+++ b/packages/default-theme/src/layouts/error.vue
@@ -30,7 +30,7 @@
 </template>
 <script>
 import { SfHeading, SfIcon, SfImage } from "@storefront-ui/vue"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 
 const customMessageDictionary = {
   404: "We can't find what you are looking for. Are you lost?",

--- a/packages/default-theme/src/pages/_.vue
+++ b/packages/default-theme/src/pages/_.vue
@@ -4,12 +4,12 @@
   </div>
 </template>
 <script>
-import { useCms, useNotifications, useDomains } from "@shopware-pwa/composables"
-import languagesMap from "sw-plugins/languages"
+import { useCms, useNotifications } from "@shopware-pwa/composables"
 
 const pagesMap = {
-  "frontend.navigation.page": () => import("@/components/views/CategoryView"),
-  "frontend.detail.page": () => import("@/components/views/ProductView"),
+  "frontend.navigation.page": () =>
+    import("@/components/views/CategoryView.vue"),
+  "frontend.detail.page": () => import("@/components/views/ProductView.vue"),
 }
 
 export function getComponentBy(resourceType) {

--- a/packages/default-theme/src/pages/account/addresses/index.vue
+++ b/packages/default-theme/src/pages/account/addresses/index.vue
@@ -28,7 +28,7 @@
 
 <script>
 import SwAddressList from "@/components/SwAddressList.vue"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 import { SfTabs } from "@storefront-ui/vue"
 export default {
   name: "MyAddresses",

--- a/packages/default-theme/src/pages/account/orders/_id.vue
+++ b/packages/default-theme/src/pages/account/orders/_id.vue
@@ -7,7 +7,7 @@
 
 <script>
 import { SfHeading } from "@storefront-ui/vue"
-import SwOrderDetails from "@/components/SwOrderDetails"
+import SwOrderDetails from "@/components/SwOrderDetails.vue"
 
 export default {
   components: { SfHeading, SwOrderDetails },

--- a/packages/default-theme/src/pages/account/orders/index.vue
+++ b/packages/default-theme/src/pages/account/orders/index.vue
@@ -31,7 +31,7 @@
 <script>
 import { SfTabs, SfTable } from "@storefront-ui/vue"
 import { useUser } from "@shopware-pwa/composables"
-import Order from "@/components/account/orders/Order"
+import Order from "@/components/account/orders/Order.vue"
 
 export default {
   name: "OrderHistory",

--- a/packages/default-theme/src/pages/account/profile.vue
+++ b/packages/default-theme/src/pages/account/profile.vue
@@ -33,8 +33,8 @@
 
 <script>
 import { SfTabs } from "@storefront-ui/vue"
-import SwPassword from "@/components/forms/SwPassword"
-import SwPersonalInfo from "@/components/forms/SwPersonalInfo"
+import SwPassword from "@/components/forms/SwPassword.vue"
+import SwPersonalInfo from "@/components/forms/SwPersonalInfo.vue"
 
 export default {
   name: "MyProfile",

--- a/packages/default-theme/src/pages/checkout.vue
+++ b/packages/default-theme/src/pages/checkout.vue
@@ -46,12 +46,12 @@
 </template>
 <script>
 import { SfSteps } from "@storefront-ui/vue"
-import SidebarOrderReview from "@/components/checkout/sidebar/SidebarOrderReview"
-import SidebarOrderSummary from "@/components/checkout/sidebar/SidebarOrderSummary"
-import PaymentStep from "@/components/checkout/steps/PaymentStep"
-import PersonalDetailsStep from "@/components/checkout/steps/PersonalDetailsStep"
-import ShippingStep from "@/components/checkout/steps/ShippingStep"
-import OrderReviewStep from "@/components/checkout/steps/OrderReviewStep"
+import SidebarOrderReview from "@/components/checkout/sidebar/SidebarOrderReview.vue"
+import SidebarOrderSummary from "@/components/checkout/sidebar/SidebarOrderSummary.vue"
+import PaymentStep from "@/components/checkout/steps/PaymentStep.vue"
+import PersonalDetailsStep from "@/components/checkout/steps/PersonalDetailsStep.vue"
+import ShippingStep from "@/components/checkout/steps/ShippingStep.vue"
+import OrderReviewStep from "@/components/checkout/steps/OrderReviewStep.vue"
 import { CHECKOUT_STEPS, useUICheckoutPage } from "@/logic/checkout"
 
 export default {

--- a/packages/default-theme/src/pages/login.vue
+++ b/packages/default-theme/src/pages/login.vue
@@ -11,7 +11,7 @@
 <script>
 import { SfHeading } from "@storefront-ui/vue"
 
-import SwLogin from "@/components/SwLogin"
+import SwLogin from "@/components/SwLogin.vue"
 import { PAGE_ACCOUNT } from "@/helpers/pages"
 import authMiddleware from "@/middleware/auth"
 

--- a/packages/default-theme/src/pages/order.vue
+++ b/packages/default-theme/src/pages/order.vue
@@ -16,9 +16,9 @@
 <script>
 import { SfHeading, SfIcon, SfDivider } from "@storefront-ui/vue"
 import { computed } from "@vue/composition-api"
-import SwButton from "@/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton.vue"
 
-import SwOrderDetails from "@/components/SwOrderDetails"
+import SwOrderDetails from "@/components/SwOrderDetails.vue"
 
 export default {
   name: "OrderPage",

--- a/packages/default-theme/src/pages/search.vue
+++ b/packages/default-theme/src/pages/search.vue
@@ -22,8 +22,8 @@ import { SfLoader } from "@storefront-ui/vue"
 import { useUIState, useListing } from "@shopware-pwa/composables"
 
 import { computed, ref } from "@vue/composition-api"
-import SwProductListing from "@/components/SwProductListing"
-import SwProductListingFilters from "@/components/SwProductListingFilters"
+import SwProductListing from "@/components/SwProductListing.vue"
+import SwProductListingFilters from "@/components/SwProductListingFilters.vue"
 
 export default {
   name: "SearchResultsPage",

--- a/packages/default-theme/src/pages/wishlist.vue
+++ b/packages/default-theme/src/pages/wishlist.vue
@@ -34,7 +34,7 @@
 <script>
 import { getProducts } from "@shopware-pwa/shopware-6-client"
 import { getApplicationContext, useWishlist } from "@shopware-pwa/composables"
-import SwProductCard from "@/components/SwProductCard"
+import SwProductCard from "@/components/SwProductCard.vue"
 import { SfHeading, SfImage, SfLoader } from "@storefront-ui/vue"
 import { onMounted, ref, watch } from "@vue/composition-api"
 


### PR DESCRIPTION
## Changes

Following good practices component imports should have .vue extension:

> You should always use the .vue extension when importing Vue components, as omitting the extension creates numerous problems for static analysis tools. It was a mistake to allow it in vue-cli and we will likely disable it in the future.

source: https://twitter.com/youyuxi/status/1288859415878283264
