### PR TITLE
fix(cli): remove slash from default endpoint

### DIFF
--- a/packages/cli/src/extensions/shopware-pwa-extension.ts
+++ b/packages/cli/src/extensions/shopware-pwa-extension.ts
@@ -8,10 +8,10 @@ const INSTANCE_READ_API_KEY = "SWIACLLVSWNJQZKYRUDJYJHIWA";
 const INSTANCE_READ_API_SECRET =
   "S0FMSjU4R3VFZ1Bkdjc1RGlhcE52MkNZbU1LVkhENHRFU1NxNjE";
 const defaultConfig = {
-  shopwareEndpoint: "https://pwa-demo-api.shopware.com/prev/",
+  shopwareEndpoint: "https://pwa-demo-api.shopware.com/prev",
   shopwareAccessToken: "SWSC40-LJTNO6COUEN7CJMXKLA",
   theme: "@shopware-pwa/default-theme",
-  pwaHost: "https://pwa-demo-api.shopware.com/prev/",
+  pwaHost: "https://pwa-demo-api.shopware.com/prev",
   shopwareApiClient: {
     timeout: 10000,
   },


### PR DESCRIPTION
## Changes

prevents 500 error while requesting shopware instance caused by two slashes in request's url. 

<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
