### PR TITLE
refactor(composables): smaller bundle size

### DIFF
--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -23,17 +23,16 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@shopware-pwa/helpers": "0.7.2",
     "@shopware-pwa/shopware-6-client": "0.7.2",
     "@vue/composition-api": "^1.0.0-rc.3",
     "axios": "^0.21.1",
     "cookie-universal": "^2.1.4",
     "query-string": "^6.14.1",
-    "vue": "^2.6.12"
+    "vue": "^2.6.12",
+    "lodash": "^4.17.21"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "devDependencies": {
-    "lodash": "^4.17.21"
   }
 }

--- a/scripts/linkDependencies.js
+++ b/scripts/linkDependencies.js
@@ -54,6 +54,10 @@ async function run() {
     stdio: "inherit",
     cwd: defaultThemeDir,
   });
+  await execa("yarn", ["link", "@shopware-pwa/helpers"], {
+    stdio: "inherit",
+    cwd: composablesDir,
+  });
 
   /**
    * Link commons


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
reduce composables bundle size, by not bundling helpers and lodash merge method

