### PR TITLE
feat: native TypeScript support in components, plugins, theme and project

### DIFF
--- a/docs/landing/operations/migrations/0.8.x_to_0.9.x.md
+++ b/docs/landing/operations/migrations/0.8.x_to_0.9.x.md
@@ -1,4 +1,4 @@
-# Migrate version 0.8.x to 0.9.x <Badge text="canary" type="warning"/>
+# Changes description and Migrate version 0.8.x to 0.9.x <Badge text="canary" type="warning"/>
 
 ## Nuxt config changes <Badge text="BREAKING CHANGE" type="error"/>
 
@@ -19,3 +19,8 @@ export default extendNuxtConfig({
 ::: tip
 It will not break your current project, but not using `extendNuxtConfig` method can cause troubles in the future. That's why this is marked as a breaking change
 :::
+
+## Native TypeScript support
+
+You can use TypeScript natively across the project, plugins, theme and logic.
+Just add `<script lang="ts">` in your components to start using it there. All your files can be written in `.ts` files.

--- a/packages/cli/src/templates/project-template/package.json
+++ b/packages/cli/src/templates/project-template/package.json
@@ -13,18 +13,18 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.13.1",
     "@nuxtjs/pwa": "^3.3.5",
-    "core-js": "^3.9.1",
-    "nuxt": "^2.15.3"
+    "core-js": "^3.11.0",
+    "nuxt": "^2.15.4"
   },
   "devDependencies": {
     "@shopware-pwa/nuxt-module": "latest",
-    "@vue/test-utils": "^1.1.3",
+    "@vue/test-utils": "^1.1.4",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^26.6.3",
-    "eslint-config-prettier": "^8.1.0",
-    "eslint-plugin-prettier": "^3.3.1",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-prettier": "^3.4.0",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
-    "vue-jest": "^3.0.4"
+    "vue-jest": "^3.0.7"
   }
 }

--- a/packages/cli/src/templates/project-template/tsconfig.json
+++ b/packages/cli/src/templates/project-template/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["ESNext", "ESNext.AsyncIterable", "DOM"],
+    "esModuleInterop": true,
+    "allowJs": true,
+    "sourceMap": true,
+    "strict": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"],
+      "@/*": ["./.shopware-pwa/source/*"]
+    },
+    "types": ["@types/node", "@nuxt/types"]
+  },
+  "exclude": ["node_modules"]
+}

--- a/packages/nuxt-module/__tests__/__snapshots__/extendNuxtConfig.spec.ts.snap
+++ b/packages/nuxt-module/__tests__/__snapshots__/extendNuxtConfig.spec.ts.snap
@@ -5,6 +5,7 @@ Object {
   "axios": Object {},
   "build": Object {},
   "buildModules": Array [
+    "@nuxt/typescript-build",
     "@shopware-pwa/nuxt-module",
   ],
   "components": false,

--- a/packages/nuxt-module/__tests__/extendNuxtConfig.spec.ts
+++ b/packages/nuxt-module/__tests__/extendNuxtConfig.spec.ts
@@ -20,6 +20,7 @@ describe("nuxt-module - extendNuxtConfig", () => {
       buildModules: ["some-new-module"],
     });
     expect(result.buildModules).toEqual([
+      "@nuxt/typescript-build",
       "@shopware-pwa/nuxt-module",
       "some-new-module",
     ]);

--- a/packages/nuxt-module/plugins/api-client.js
+++ b/packages/nuxt-module/plugins/api-client.js
@@ -64,17 +64,12 @@ export default async ({ app }, inject) => {
     }
   });
 
-  const { preloadRef } = useSharedState(app);
-  const { sessionContext, refreshSessionContext } = useSessionContext(app);
-  preloadRef(sessionContext, async () => {
-    await refreshSessionContext();
-  });
-  const { refreshUser, user } = useUser(app);
-  preloadRef(user, async () => {
-    await refreshUser();
-  });
-  const { refreshCart, cart } = useCart(app);
-  preloadRef(cart, async () => {
-    await refreshCart();
-  });
+  if (process.client) {
+    const { refreshSessionContext } = useSessionContext(app);
+    refreshSessionContext();
+    const { refreshUser } = useUser(app);
+    refreshUser();
+    const { refreshCart } = useCart(app);
+    refreshCart();
+  }
 };

--- a/packages/nuxt-module/src/extendNuxtConfig.ts
+++ b/packages/nuxt-module/src/extendNuxtConfig.ts
@@ -40,7 +40,7 @@ const defaultConfig: NuxtConfig = {
   components: false,
 
   // Modules for dev and build (recommended): https://go.nuxtjs.dev/config-modules
-  buildModules: ["@shopware-pwa/nuxt-module"],
+  buildModules: ["@nuxt/typescript-build", "@shopware-pwa/nuxt-module"],
 
   // Modules: https://go.nuxtjs.dev/config-modules
   modules: [


### PR DESCRIPTION
## Native TypeScript support

You can use TypeScript natively across the project, plugins, theme and logic.
Just add `<script lang="ts">` in your components to start using it there. All your files can be written in `.ts` files.

Quick example:
![image](https://user-images.githubusercontent.com/13100280/116062605-595b9480-a684-11eb-9d05-2c0b843fdd15.png)


![image](https://user-images.githubusercontent.com/13100280/116062641-65475680-a684-11eb-8720-7f2401081a20.png)

![image](https://user-images.githubusercontent.com/13100280/116062691-6ed0be80-a684-11eb-84cd-0b6735a6c352.png)

![image](https://user-images.githubusercontent.com/13100280/116062795-86a84280-a684-11eb-8ae6-87ee92418c76.png)
