### PR TITLE
chore(composables): missing translated names

### DIFF
--- a/packages/composables/src/internalHelpers/defaultApiParams.json
+++ b/packages/composables/src/internalHelpers/defaultApiParams.json
@@ -108,11 +108,13 @@
       "product_group_option": [
         "id",
         "group",
-        "translated"
+        "translated",
+        "name"
       ],
       "product_group": [
         "id",
-        "translated"
+        "translated",
+        "name"
       ],
       "product_listing": [
         "sorting",
@@ -128,10 +130,12 @@
       "property_group": [
         "id",
         "translated",
-        "options"
+        "options",
+        "name"
       ],
       "property_group_option": [
         "translated",
+        "name",
         "id",
         "colorHexCode",
         "media",
@@ -139,7 +143,8 @@
       ],
       "product_manufacturer": [
         "translated",
-        "link"
+        "link",
+        "name"
       ]
     }
   },
@@ -191,6 +196,7 @@
       ],
       "property_group_option": [
         "translated",
+        "name",
         "id",
         "colorHexCode",
         "media",


### PR DESCRIPTION
## Changes

solves issue when the property isn't contained in the request's "includes" parameter, it won't be assigned into translated object as well.


<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
