### PR TITLE
feat(cli): check API access on init

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -69,6 +69,7 @@ module.exports = {
       Object.assign(inputParameters, answers);
     }
 
+    await toolbox.checkApiCompatibility();
     await toolbox.generateNuxtProject();
 
     const defaultVersion = availablePwaVersions[0];

--- a/packages/cli/src/extensions/shopware-pwa-extension.ts
+++ b/packages/cli/src/extensions/shopware-pwa-extension.ts
@@ -177,6 +177,8 @@ module.exports = (toolbox: GluegunToolbox) => {
    */
 
   toolbox.checkApiCompatibility = async () => {
+    const checkingSpinner = toolbox.print.spin("Checking the provided API...");
+
     try {
       await axios.post(
         `${toolbox.normalizeBaseUrl(
@@ -191,9 +193,10 @@ module.exports = (toolbox: GluegunToolbox) => {
           },
         }
       );
-      toolbox.print.success("✓ PWA plugin installed");
+      checkingSpinner.succeed("PWA plugin is installed");
       return;
     } catch (error) {
+      checkingSpinner.stop();
       toolbox.print.error(
         "✘ PWA plugin is probably not installed yet.\n- Check if your Shopware6 API is reachable\n- Visit https://github.com/elkmod/SwagShopwarePwa for more information."
       );

--- a/packages/cli/src/extensions/shopware-pwa-extension.ts
+++ b/packages/cli/src/extensions/shopware-pwa-extension.ts
@@ -170,4 +170,32 @@ module.exports = (toolbox: GluegunToolbox) => {
   toolbox.normalizeBaseUrl = (baseUrl: string): string => {
     return toolbox.strings.trimEnd(baseUrl, "/");
   };
+
+  /**
+   * Checks if provided API has PWA extension installed
+   */
+
+  toolbox.checkApiCompatibility = async () => {
+    try {
+      await axios.post(
+        `${toolbox.normalizeBaseUrl(
+          toolbox.config.shopwareEndpoint
+        )}/store-api/pwa/page`,
+        {
+          path: "/",
+        },
+        {
+          headers: {
+            "sw-access-key": toolbox.config.shopwareAccessToken,
+          },
+        }
+      );
+      toolbox.print.success("✓ PWA plugin installed");
+      return;
+    } catch (error) {
+      toolbox.print.error(
+        "✘ PWA plugin is probably not installed yet.\n- Check if your Shopware6 API is reachable\n- Visit https://github.com/elkmod/SwagShopwarePwa for more information."
+      );
+    }
+  };
 };

--- a/packages/cli/src/extensions/shopware-pwa-extension.ts
+++ b/packages/cli/src/extensions/shopware-pwa-extension.ts
@@ -198,7 +198,7 @@ module.exports = (toolbox: GluegunToolbox) => {
     } catch (error) {
       checkingSpinner.stop();
       toolbox.print.error(
-        "✘ PWA plugin is probably not installed yet.\n- Check if your Shopware6 API is reachable\n- Visit https://github.com/elkmod/SwagShopwarePwa for more information."
+        "✘ PWA plugin is probably not installed yet on your Shopware 6 instance.\n- Check if your Shopware6 API is reachable\n- Visit https://github.com/elkmod/SwagShopwarePwa for more information."
       );
     }
   };

--- a/packages/cli/src/extensions/shopware-pwa-extension.ts
+++ b/packages/cli/src/extensions/shopware-pwa-extension.ts
@@ -173,6 +173,7 @@ module.exports = (toolbox: GluegunToolbox) => {
 
   /**
    * Checks if provided API has PWA extension installed
+   * by making a request to the page resolver
    */
 
   toolbox.checkApiCompatibility = async () => {


### PR DESCRIPTION
## Changes

closes #1517 

- checking if there is not 404 on page resolver's endpoint (default "/" path).

possibly todo: 
 - if there is 404 not thrown by Symfony's controller but the page resolver's one.
 - distinct 500 & 404, but if there is something wrong with API should be treated as a blocker - as same as an not installed plugin IMO

<!-- Paste here screenshot if there are visual changes -->

![Screenshot from 2021-05-31 11-44-52](https://user-images.githubusercontent.com/5596960/120182277-7c8edc00-c20e-11eb-80b9-5d9ef2cf0e3c.png)
![Screenshot from 2021-05-31 11-44-28](https://user-images.githubusercontent.com/5596960/120182278-7d277280-c20e-11eb-95d5-b54f324a0b20.png)



### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
