### PR TITLE
fix(nuxt-module): sort routes with localhost and port domains

### DIFF
--- a/packages/nuxt-module/src/domains.ts
+++ b/packages/nuxt-module/src/domains.ts
@@ -112,6 +112,14 @@ export async function setupDomains(
       // force the path of last change to be last one in the routes list
       wildCardIndexFound &&
         domainsRoutes.push(domainsRoutes.splice(wildCardIndexFound, 1)[0]);
+
+      // search for case like /:3000/* and move it to the end of the list
+      const paramsIndex = domainsRoutes.findIndex((v) =>
+        /\/:.*\/\*/.test(v.path)
+      );
+      paramsIndex &&
+        domainsRoutes.push(domainsRoutes.splice(paramsIndex, 1)[0]);
+
       routes.splice(0, routes.length, ...domainsRoutes); // force replace the new routes table
     }
   };


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

Fix local routes when a domain like `:3000` is registered

<!-- Paste here screenshot if there are visual changes -->
