### PR TITLE
fix(default-theme): auth middleware based on route names allowing to show account page

### DIFF
--- a/packages/default-theme/src/middleware/auth.js
+++ b/packages/default-theme/src/middleware/auth.js
@@ -1,23 +1,16 @@
 import { useUser } from "@shopware-pwa/composables"
 import { PAGE_LOGIN } from "@/helpers/pages"
-const LOGIN_ROUTE_NAME = "login"
-
-const PAGES_FOR_LOGGED_IN_ONLY = [
-  "account", // user's account page
-  "account-profile",
-  "account-orders",
-  "account-addresses",
-]
 
 /**
  * 1. Check if requesting route is restricted only for authenticated user
  * 2. Redirect to /login otherwise (always force logout on /login route)
  */
 export default async function ({ route, redirect, app }) {
-  const { isLoggedIn, logout, refreshUser } = useUser(app)
+  const { isLoggedIn, logout, refreshUser, isGuestSession } = useUser(app)
 
-  if (route.name === LOGIN_ROUTE_NAME) {
+  if (route.path === PAGE_LOGIN) {
     await logout()
+    return
   }
   try {
     await refreshUser()
@@ -26,11 +19,7 @@ export default async function ({ route, redirect, app }) {
     // 403 after logoout should be silenced
   }
 
-  if (
-    PAGES_FOR_LOGGED_IN_ONLY.includes(route.name) &&
-    isLoggedIn &&
-    !isLoggedIn.value
-  ) {
+  if (!isLoggedIn.value || isGuestSession.value) {
     redirect(PAGE_LOGIN)
   }
 }


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

closes #1561 

domains config changes route names, auth middleware was basing its checks on these names. Auth middleware is now redirecting to the login page every time it's used on some page component.