### PR TITLE
fix: use env from parent process

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -96,6 +96,9 @@ async function runBuild({
     const peerDependencies = Object.keys(packageJson.peerDependencies || {});
     const external = [...dependencies, ...peerDependencies];
     await esBuild({
+      define: {
+        "process.env.NODE_ENV": '"production"',
+      },
       entryPoints: [path.join("packages", target, "src", "index.ts")],
       outfile: path.join("packages", target, "dist", `${target}.${format}.js`),
       minify: false,
@@ -121,6 +124,9 @@ async function runBuild({
           external,
           target: buildTarget,
           format,
+          define: {
+            "process.env.NODE_ENV": '"production"',
+          },
         });
       });
       await Promise.all(promisses);
@@ -162,7 +168,13 @@ async function build(target) {
 
   // run custom package build if there is one
   if (pkg.scripts && pkg.scripts.build) {
-    await execa("yarn", ["build"], { stdio: "inherit", cwd: pkgDir });
+    await execa("yarn", ["build"], {
+      stdio: "inherit",
+      cwd: pkgDir,
+      env: {
+        NODE_ENV: "production",
+      },
+    });
     return;
   }
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -91,17 +91,17 @@ async function runBuild({
 }) {
   const buildTarget = format === "esm" ? "es2020" : "es2015";
 
+  const define = {
+    "process.env.NODE_ENV":
+      process.env.NODE_ENV === "development" ? '"development"' : '"production"',
+  };
+
   try {
     const dependencies = Object.keys(packageJson.dependencies || {});
     const peerDependencies = Object.keys(packageJson.peerDependencies || {});
     const external = [...dependencies, ...peerDependencies];
     await esBuild({
-      define: {
-        "process.env.NODE_ENV":
-          process.env.NODE_ENV === "development"
-            ? '"development"'
-            : '"production"',
-      },
+      define,
       entryPoints: [path.join("packages", target, "src", "index.ts")],
       outfile: path.join("packages", target, "dist", `${target}.${format}.js`),
       minify: false,
@@ -127,12 +127,7 @@ async function runBuild({
           external,
           target: buildTarget,
           format,
-          define: {
-            "process.env.NODE_ENV":
-              process.env.NODE_ENV === "development"
-                ? '"development"'
-                : '"production"',
-          },
+          define,
         });
       });
       await Promise.all(promisses);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -90,18 +90,13 @@ async function runBuild({
   additionalEntrypoints = [],
 }) {
   const buildTarget = format === "esm" ? "es2020" : "es2015";
-
-  const define = {
-    "process.env.NODE_ENV":
-      process.env.NODE_ENV === "development" ? '"development"' : '"production"',
-  };
+  const platform = format === "cjs" ? "node" : "neutral";
 
   try {
     const dependencies = Object.keys(packageJson.dependencies || {});
     const peerDependencies = Object.keys(packageJson.peerDependencies || {});
     const external = [...dependencies, ...peerDependencies];
     await esBuild({
-      define,
       entryPoints: [path.join("packages", target, "src", "index.ts")],
       outfile: path.join("packages", target, "dist", `${target}.${format}.js`),
       minify: false,
@@ -109,6 +104,7 @@ async function runBuild({
       external,
       target: buildTarget,
       format,
+      platform,
     });
     if (additionalEntrypoints.length) {
       const promisses = additionalEntrypoints.map((entrypoint) => {
@@ -127,7 +123,7 @@ async function runBuild({
           external,
           target: buildTarget,
           format,
-          define,
+          platform,
         });
       });
       await Promise.all(promisses);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -97,7 +97,10 @@ async function runBuild({
     const external = [...dependencies, ...peerDependencies];
     await esBuild({
       define: {
-        "process.env.NODE_ENV": '"production"',
+        "process.env.NODE_ENV":
+          process.env.NODE_ENV === "development"
+            ? '"development"'
+            : '"production"',
       },
       entryPoints: [path.join("packages", target, "src", "index.ts")],
       outfile: path.join("packages", target, "dist", `${target}.${format}.js`),
@@ -125,7 +128,10 @@ async function runBuild({
           target: buildTarget,
           format,
           define: {
-            "process.env.NODE_ENV": '"production"',
+            "process.env.NODE_ENV":
+              process.env.NODE_ENV === "development"
+                ? '"development"'
+                : '"production"',
           },
         });
       });
@@ -171,9 +177,6 @@ async function build(target) {
     await execa("yarn", ["build"], {
       stdio: "inherit",
       cwd: pkgDir,
-      env: {
-        NODE_ENV: "production",
-      },
     });
     return;
   }

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -41,10 +41,16 @@ if (pkg.scripts && pkg.scripts.dev) {
     .on("all", async (event) => {
       execa("yarn", ["build", target], {
         stdio: "inherit",
+        env: {
+          NODE_ENV: "development",
+        },
       });
     });
 
   execa("yarn", ["build", target], {
     stdio: "inherit",
+    env: {
+      NODE_ENV: "development",
+    },
   });
 }

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -41,16 +41,10 @@ if (pkg.scripts && pkg.scripts.dev) {
     .on("all", async (event) => {
       execa("yarn", ["build", target], {
         stdio: "inherit",
-        env: {
-          NODE_ENV: "development",
-        },
       });
     });
 
   execa("yarn", ["build", target], {
     stdio: "inherit",
-    env: {
-      NODE_ENV: "development",
-    },
   });
 }


### PR DESCRIPTION
## Changes

closes: #1574 


enforces building packages in production mode to avoid a mode mixing when the nuxt builds the application and gets the pre-built packages. 

<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
