### PR TITLE
fix(cli): plugins pages clearing on the runtime

### DIFF
--- a/packages/cli/__tests__/buildPluginsTrace.spec.ts
+++ b/packages/cli/__tests__/buildPluginsTrace.spec.ts
@@ -145,21 +145,6 @@ describe("CLI extensions - plugins - buildPluginsTrace", () => {
   });
 
   describe("custom pages and layouts", () => {
-    it("should clear plugins layouts and pages cache", async () => {
-      const pluginsConfig = {
-        "first-plugin": false,
-      };
-      await toolbox.buildPluginsTrace({
-        pluginsConfig,
-      });
-      expect(toolbox.filesystem.removeAsync).toBeCalledWith(
-        ".shopware-pwa/sw-plugins/pages"
-      );
-      expect(toolbox.filesystem.removeAsync).toBeCalledWith(
-        ".shopware-pwa/sw-plugins/layouts"
-      );
-    });
-
     it("should add plugin layouts to cache and runtime directory", async () => {
       toolbox.filesystem.exists.mockReturnValueOnce("dir");
       toolbox.filesystem.exists.mockReturnValueOnce(false);

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -75,6 +75,9 @@ module.exports = {
       props: {},
     });
 
+    await toolbox.filesystem.removeAsync(".shopware-pwa/sw-plugins/pages");
+    await toolbox.filesystem.removeAsync(".shopware-pwa/sw-plugins/layouts");
+
     const pluginsConfig = await toolbox.plugins.getPluginsConfig();
     const shopwarePluginsTrace = await toolbox.buildPluginsTrace({
       pluginsConfig,

--- a/packages/cli/src/extensions/plugins-extensions.ts
+++ b/packages/cli/src/extensions/plugins-extensions.ts
@@ -167,8 +167,6 @@ module.exports = (toolbox: GluegunToolbox) => {
     const pluginsMap = Object.assign({}, pluginsTrace);
     if (pluginsConfig) {
       const pluginNames = Object.keys(pluginsConfig);
-      await toolbox.filesystem.removeAsync(".shopware-pwa/sw-plugins/pages");
-      await toolbox.filesystem.removeAsync(".shopware-pwa/sw-plugins/layouts");
       pluginNames.forEach((pluginName) => {
         if (!pluginsConfig[pluginName]) return;
         const pluginDirectory = `${pluginsRootDirectory}/${pluginName}`;


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

<!-- Paste here screenshot if there are visual changes -->

fixes problem with plugin pages and layouts clearing on the runtime
