### PR TITLE
fix(composables): memory leak in the page middleware

### DIFF
--- a/packages/composables/src/hooks/useCms/index.ts
+++ b/packages/composables/src/hooks/useCms/index.ts
@@ -1,4 +1,4 @@
-import { Ref, computed, ComputedRef, watch } from "vue-demi";
+import { Ref, computed, ComputedRef } from "vue-demi";
 import { getCmsPage } from "@shopware-pwa/shopware-6-client";
 import { SearchCriteria } from "@shopware-pwa/commons/interfaces/search/SearchCriteria";
 import { parseUrlQuery } from "@shopware-pwa/helpers";
@@ -59,15 +59,6 @@ export function useCms(rootContext: ApplicationVueContext): {
     return page.value?.resourceIdentifier || null;
   });
 
-  watch(
-    page,
-    (pageValue) => {
-      pageValue?.breadcrumb &&
-        setBreadcrumbs(Object.values(pageValue.breadcrumb));
-    },
-    { immediate: true }
-  );
-
   /**
    * @beta
    */
@@ -82,6 +73,7 @@ export function useCms(rootContext: ApplicationVueContext): {
     try {
       const result = await getCmsPage(path, searchCriteria, apiInstance);
       _storePage.value = result;
+      result?.breadcrumb && setBreadcrumbs(Object.values(result.breadcrumb));
     } catch (e) {
       const err: ClientApiError = e;
       _cmsError.value = err;


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
The issue raised to me by @niklaswolf 
We had a memory leak caused by the watcher invoked on the server-side in the page middleware. I traced that down and after this fix, I see no signs of that.
After we'll confirm that the problem is solved I'll backport it to 0.9 and 0.8 versions as it is a pretty important thing and the fix is not breaking anything.
