### PR TITLE
fix(nuxt-module): ability to add new config key for defaults

### DIFF
--- a/packages/nuxt-module/__tests__/defaultsConfigBuilder.spec.ts
+++ b/packages/nuxt-module/__tests__/defaultsConfigBuilder.spec.ts
@@ -52,6 +52,17 @@ describe("nuxt-module - defaultsConfigBuilder", () => {
         associations: { media: {}, something: {} },
       });
     });
+
+    it("should add new key to config", () => {
+      const result = defaultsConfigBuilder()
+        .add("myNewKey", {
+          someConfig: 123,
+        })
+        .get();
+      expect(result.myNewKey).toEqual({
+        someConfig: 123,
+      });
+    });
   });
 
   describe("replace", () => {

--- a/packages/nuxt-module/src/defaultsConfigBuilder.ts
+++ b/packages/nuxt-module/src/defaultsConfigBuilder.ts
@@ -276,7 +276,9 @@ export default function defaultsConfigBuilder() {
      */
     add: (key: string, config: unknown) => {
       const property = get(finalConfig, key);
-      if (Array.isArray(property) && !Array.isArray(config)) {
+      if (!property) {
+        set(finalConfig, key, config);
+      } else if (Array.isArray(property) && !Array.isArray(config)) {
         mergeWith(property, [config], _customizer);
       } else {
         mergeWith(property, config, _customizer);


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #1514 

<!-- Paste here screenshot if there are visual changes -->
Testing the scenario from the issue I saw that a new key is not created when the path is set.


