### PR TITLE
docs: correct link to prepare-shopware.html

### DIFF
--- a/docs/landing/operations/deployment/README.md
+++ b/docs/landing/operations/deployment/README.md
@@ -79,4 +79,4 @@ export default {
 ## More on that
 
 - [Nuxt.js Docs on Commands & Deployment](https://nuxtjs.org/guide/commands)
-- [Prepare Shopware instance](http://localhost:8080/landing/getting-started/prepare-shopware.html)
+- [Prepare Shopware instance](https://shopware-pwa-docs.vuestorefront.io/landing/getting-started/prepare-shopware.html)


### PR DESCRIPTION
## Changes

Changed link from localhost to https://shopware-pwa-docs.vuestorefront.io/ in /docs/landing/operations/deployment/README.md 

<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [X] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [X] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
