### PR TITLE
POC: allow to override current context token in api-client

### DIFF
--- a/packages/default-theme/src/components/SwOrderDetails.vue
+++ b/packages/default-theme/src/components/SwOrderDetails.vue
@@ -269,6 +269,10 @@ export default {
   setup({ orderId }, { root }) {
     const { getPaymentMethods } = useCheckout(root)
     const { pushWarning } = useNotifications(root)
+    const { apiInstance, routing } = getApplicationContext(root)
+    const currentContextToken = computed(
+      () => apiInstance?.config?.contextToken
+    )
     const {
       order,
       status,
@@ -306,7 +310,14 @@ export default {
 
     const changePaymentMethod = async () => {
       await doChangePaymentMethod(selectedPaymentMethod.value)
-      await handlePayment()
+      await handlePayment(
+        routing.getAbsoluteUrl(
+          `${PAGE_ORDER_SUCCESS}?contextToken=${currentContextToken.value}&orderId=${orderId}`
+        ),
+        routing.getAbsoluteUrl(
+          `${PAGE_ORDER_PAYMENT_FAILURE}?contextToken=${currentContextToken.value}&orderId=${orderId}`
+        )
+      )
       changePaymentMethodModalVisible.value = false
     }
 
@@ -320,7 +331,14 @@ export default {
 
     onMounted(() => {
       loadOrderDetails()
-      handlePayment()
+      handlePayment(
+        routing.getAbsoluteUrl(
+          `${PAGE_ORDER_SUCCESS}?contextToken=${currentContextToken.value}&orderId=${orderId}`
+        ),
+        routing.getAbsoluteUrl(
+          `${PAGE_ORDER_PAYMENT_FAILURE}?contextToken=${currentContextToken.value}&orderId=${orderId}`
+        )
+      )
     })
 
     return {

--- a/packages/default-theme/src/logic/useDomains.js
+++ b/packages/default-theme/src/logic/useDomains.js
@@ -11,6 +11,8 @@ import { getCmsTechnicalPath } from "@shopware-pwa/helpers"
 const PAGE_RESOLVER_ROUTE_PREFIX = "all_"
 
 export function useDomains(rootContext) {
+  const { resourceIdentifier, page } = useCms()
+
   const { router, routing, apiInstance } = getApplicationContext(
     rootContext,
     "useDomains"
@@ -42,7 +44,6 @@ export function useDomains(rootContext) {
     if (isRouteStatic.value) {
       path += getCurrentPathWithoutDomain()
     } else {
-      const { resourceIdentifier, page } = useCms()
       try {
         // find the correspoding URL for current page if it comes from page resolver - dynamically generated
         const seoResponse = await getSeoUrls(

--- a/packages/default-theme/src/pages/checkout.vue
+++ b/packages/default-theme/src/pages/checkout.vue
@@ -178,17 +178,18 @@ export default {
       try {
         // 1. place an order
         const order = await invokeCreateOrder()
+        const currentContextToken = apiInstance?.config?.contextToken
         // 2. call handle-payment endpoint for further actions
         const handledPaymentResponse = await handlePayment(
           order.id,
           // pass finishUrl as a success page (used only in async payment flow)
           root.$routing.getAbsoluteUrl(
-            `${PAGE_ORDER_SUCCESS}?orderId=${order.id}`
+            `${PAGE_ORDER_SUCCESS}?contextToken=${currentContextToken}&orderId=${order.id}`
           ),
           // pass errorUrl as a failure page when the payment isn't done successfully
           // (used only in async payment flow)
           root.$routing.getAbsoluteUrl(
-            `${PAGE_ORDER_PAYMENT_FAILURE}?orderId=${order.id}`
+            `${PAGE_ORDER_PAYMENT_FAILURE}?contextToken=${currentContextToken}&orderId=${order.id}`
           ),
           apiInstance
         )

--- a/packages/nuxt-module/plugins/api-client.js
+++ b/packages/nuxt-module/plugins/api-client.js
@@ -2,11 +2,12 @@ import { createInstance } from "@shopware-pwa/shopware-6-client";
 import { useUser, useCart, useSessionContext } from "@shopware-pwa/composables";
 import { reactive } from "vue-demi";
 
-export default async ({ app }, inject) => {
+export default async ({ app, query }, inject) => {
   if (!app.$cookies) {
     throw "Error cookie-universal-nuxt module is not applied in nuxt.config.js";
   }
-  const contextToken = app.$cookies.get("sw-context-token") || "";
+  const contextToken =
+    query?.contextToken || app.$cookies.get("sw-context-token") || "";
   const languageId = app.$cookies.get("sw-language-id") || "";
 
   /**


### PR DESCRIPTION
_**It's not a part of the core since the issue is cased by the browser's behaviour and the way how async payment processors redirects the customers (302 gets only location header on apple devices) to the finishUrl (handle-payment process).**_ 


closes: #1638 

- handles "contextToken" in query and sets it as current context token in [api-client](https://github.com/vuestorefront/shopware-pwa/compare/feat/allow-to-override-context-token-from-query?expand=1#diff-63a6681f6cff31f15fe0f6b29dab647bee5ece23a8a56ad977ac4df21599fddb) instance .

- minor fixes to pass the context token in every handlePayment request


cons:
- possibility of session sharing