### PR TITLE
feat(cli): ability to disable plugins from shopware instance

### DIFF
--- a/docs/landing/getting-started/README.md
+++ b/docs/landing/getting-started/README.md
@@ -84,6 +84,61 @@ module.exports = {
 yarn dev
 ```
 
+### shopware-pwa.config.js config file
+
+Available settings inside the `shopware-pwa.config.js` file:
+
+```ts
+export interface ShopwarePwaConfigFile {
+  /**
+   * list of allowed domains for this pwa instance from saleschannel configuration
+   */
+  shopwareDomainsAllowList?: string[];
+  /**
+   * default domain prefix
+   */
+  fallbackDomain?: string;
+  /**
+   * Shopware6 URL
+   */
+  shopwareEndpoint: string;
+  /**
+   * id specific for each sales channel
+   */
+  shopwareAccessToken: string;
+  /**
+   * theme code: npm package name or local one (directory name)
+   */
+  theme: string;
+  /**
+   * default locale used in application
+   */
+  defaultLanguageCode?: string;
+  /**
+   * {ShopwareApiClientConfig}
+   */
+  shopwareApiClient?: ShopwareApiClientConfig;
+  /**
+   * List of the plugins that are installed on Shopware instance but should not be loaded.
+   */
+  disabledPlugins?: string[];
+}
+
+export interface ShopwareApiClientConfig {
+  /**
+   * value of timeout limit for the requests (ms)
+   */
+  timeout?: number;
+  /**
+   * credentials for HTTP basic auth
+   */
+  auth?: {
+    username: string;
+    password: string;
+  };
+}
+```
+
 ### How do I move on?
 
 What about...

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -1,9 +1,9 @@
-import { GluegunToolbox } from "gluegun";
+import { ShopwarePwaToolbox } from "src/types";
 
 module.exports = {
   name: "plugins",
   hidden: true,
-  run: async (toolbox: GluegunToolbox) => {
+  run: async (toolbox: ShopwarePwaToolbox) => {
     const {
       template: { generate },
       print: { success, spin },
@@ -98,8 +98,10 @@ module.exports = {
     toolbox.debug("plugins config", pluginsConfig);
     const shopwarePluginsTrace = await toolbox.buildPluginsTrace({
       pluginsConfig,
+      disabledPlugins: toolbox.config.disabledPlugins,
     });
     toolbox.debug("plugins trace", shopwarePluginsTrace);
+    toolbox.debug("disabled plugins", toolbox.config.disabledPlugins);
     // extend plugins trace from local project
     const localPluginsConfig = await toolbox.plugins.getPluginsConfig({
       localPlugins: true,

--- a/packages/cli/src/extensions/plugins-extensions.ts
+++ b/packages/cli/src/extensions/plugins-extensions.ts
@@ -124,12 +124,15 @@ module.exports = (toolbox: GluegunToolbox) => {
     pluginsConfig,
     rootDirectory,
     pluginsTrace,
+    disabledPlugins,
   }: any = {}) => {
     const pluginsRootDirectory =
       rootDirectory || ".shopware-pwa/pwa-bundles-assets";
     const pluginsMap = Object.assign({}, pluginsTrace);
     if (pluginsConfig) {
-      const pluginNames = Object.keys(pluginsConfig);
+      const pluginNames = Object.keys(pluginsConfig).filter(
+        (pluginName) => !disabledPlugins?.includes(pluginName) // filter out disabled plugins
+      );
       pluginNames.forEach((pluginName) => {
         if (!pluginsConfig[pluginName]) return;
         const pluginDirectory = `${pluginsRootDirectory}/${pluginName}`;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,5 +1,8 @@
+import { ShopwarePwaConfigFile } from "@shopware-pwa/commons";
+import { GluegunToolbox } from "gluegun";
 // export types
 
-export interface ShopwarePwaToolbox {
+export interface ShopwarePwaToolbox extends GluegunToolbox {
   isProduction: boolean;
+  config: ShopwarePwaConfigFile & { loadConfig?: () => void };
 }

--- a/packages/commons/src/defaultConfig.ts
+++ b/packages/commons/src/defaultConfig.ts
@@ -59,6 +59,10 @@ export interface ShopwarePwaConfigFile {
    * {ShopwareApiClientConfig}
    */
   shopwareApiClient?: ShopwareApiClientConfig;
+  /**
+   * List of the plugins that are installed on Shopware instance but should not be loaded.
+   */
+  disabledPlugins?: string[];
 }
 
 export interface CompatibilityTable {


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

sometimes you may want to disable plugins, which are installed on your shopware instance. Especially when you are locally developing this plugin and want to avoid duplication.
example:
```js
module.exports = {
  shopwareEndpoint: "https://pwa-demo-api.shopware.com/trunk/",
  shopwareDomainsAllowList: ["http://localhost:3000"],
  disabledPlugins: ["my-sw-plugin"],
}
```
this will disable plugin named `my-sw-plugin`