### PR TITLE
fix(nuxt-module): ssg mode not working after domains refactor

### DIFF
--- a/packages/nuxt-module/plugins/domain.js
+++ b/packages/nuxt-module/plugins/domain.js
@@ -48,7 +48,7 @@ export default async ({ app, route, req }, inject) => {
       if (process.client) {
         hostname = window.location.hostname;
         pathname = window.location.pathname;
-      } else {
+      } else if (!process.static) {
         const detectedHost =
           req.headers["x-forwarded-host"] || req.headers.host;
         hostname = Array.isArray(detectedHost) ? detectedHost[0] : detectedHost;


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #1666 

During SSG both window and request are not reachable. SSG generation should skip domain settings and react on that only on the client side.