### PR TITLE
fix(composables): added missing defaultApiParams in useUser and useCustomerAddresses

### DIFF
--- a/packages/composables/src/internalHelpers/defaultApiParams.json
+++ b/packages/composables/src/internalHelpers/defaultApiParams.json
@@ -303,7 +303,8 @@
         "id",
         "phoneNumber",
         "state",
-        "salutation"
+        "salutation",
+        "street"
       ],
       "country": ["name", "id"],
       "salutation": ["salutationKey", "displayName", "translated", "id"]

--- a/packages/composables/src/internalHelpers/defaultApiParams.json
+++ b/packages/composables/src/internalHelpers/defaultApiParams.json
@@ -322,7 +322,9 @@
         "lastName",
         "email",
         "guest",
-        "addresses"
+        "addresses",
+        "defaultBillingAddressId",
+        "defaultShippingAddressId"
       ]
     }
   }

--- a/packages/composables/src/internalHelpers/defaultApiParams.json
+++ b/packages/composables/src/internalHelpers/defaultApiParams.json
@@ -325,7 +325,8 @@
         "guest",
         "addresses",
         "defaultBillingAddressId",
-        "defaultShippingAddressId"
+        "defaultShippingAddressId",
+        "orderCount"
       ]
     }
   }


### PR DESCRIPTION
## Changes

added missing include flags for useUser (`defaultBillingAddressId`, `defaultShippingAddressId`, `orderCount`) and useCustomerAddresses (`street`) to make full listing and highlight of current selected address in SwAddressList possible again

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
