### PR TITLE
fix(composables): show add to cart errors properly

### DIFF
--- a/api/composables.api.md
+++ b/api/composables.api.md
@@ -130,7 +130,7 @@ export interface IUseCart {
     addProduct: ({ id, quantity, }: {
         id: string;
         quantity?: number;
-    }) => Promise<void>;
+    }) => Promise<Cart>;
     // (undocumented)
     addPromotionCode: (promotionCode: string) => Promise<void>;
     // (undocumented)

--- a/docs/landing/resources/api/composables.iusecart.addproduct.md
+++ b/docs/landing/resources/api/composables.iusecart.addproduct.md
@@ -13,5 +13,5 @@
 addProduct: ({ id, quantity, }: {
         id: string;
         quantity?: number;
-    }) => Promise<void>;
+    }) => Promise<Cart>;
 ```

--- a/docs/landing/resources/api/composables.iusecart.md
+++ b/docs/landing/resources/api/composables.iusecart.md
@@ -19,7 +19,7 @@ export interface IUseCart
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [addProduct](./composables.iusecart.addproduct.md) | ({ id, quantity, }: { id: string; quantity?: number; }) =&gt; Promise&lt;void&gt; | <b><i>(BETA)</i></b> |
+|  [addProduct](./composables.iusecart.addproduct.md) | ({ id, quantity, }: { id: string; quantity?: number; }) =&gt; Promise&lt;Cart&gt; | <b><i>(BETA)</i></b> |
 |  [addPromotionCode](./composables.iusecart.addpromotioncode.md) | (promotionCode: string) =&gt; Promise&lt;void&gt; | <b><i>(BETA)</i></b> |
 |  [appliedPromotionCodes](./composables.iusecart.appliedpromotioncodes.md) | ComputedRef&lt;LineItem\[\]&gt; | <b><i>(BETA)</i></b> |
 |  [cart](./composables.iusecart.cart.md) | ComputedRef&lt;Cart \| null&gt; | <b><i>(BETA)</i></b> |

--- a/packages/composables/src/logic/useAddToCart.ts
+++ b/packages/composables/src/logic/useAddToCart.ts
@@ -90,10 +90,14 @@ export function useAddToCart(params: {
     error.value = null;
     if (!quantity.value) quantity.value = 1;
     try {
-      await addProduct({ id: product.id, quantity: quantity.value });
+      const addToCartResponse = await addProduct({
+        id: product.id,
+        quantity: quantity.value,
+      });
       broadcast(INTERCEPTOR_KEYS.ADD_TO_CART, {
         product,
         quantity: quantity.value,
+        apiResponse: addToCartResponse,
       });
       quantity.value = 1;
     } catch (e) {

--- a/packages/default-theme/src/plugins/notifications.js
+++ b/packages/default-theme/src/plugins/notifications.js
@@ -19,12 +19,17 @@ export default async ({ app }) => {
       const { pushSuccess, pushWarning, pushError } = useNotifications()
       const { i18n } = getApplicationContext()
 
-      intercept(INTERCEPTOR_KEYS.ADD_TO_CART, (payload) => {
-        pushSuccess(
-          i18n.t("{productName} has been added to cart.", {
-            productName: getTranslatedProperty(payload?.product, "name"),
-          })
-        )
+      intercept(INTERCEPTOR_KEYS.ADD_TO_CART, ({ apiResponse, product }) => {
+        // ignore warning or notice type
+        const errorFound = Object.entries(apiResponse?.errors)?.find(
+          ([code, error]) => error.level === 20
+        ) // 20 is ErrorLevel.ERROR
+        errorFound ||
+          pushSuccess(
+            i18n.t("{productName} has been added to cart.", {
+              productName: getTranslatedProperty(product, "name"),
+            })
+          )
       })
 
       intercept(
@@ -59,6 +64,12 @@ export default async ({ app }) => {
 
       intercept(INTERCEPTOR_KEYS.WARNING, ({ warning }) => {
         pushWarning(warning.message)
+      })
+
+      intercept(INTERCEPTOR_KEYS.ERROR, ({ error }) => {
+        // notify on every broadcasted error.
+        // disconnect if they are not necesarry entirely, or just create conditions to filter they out
+        pushError(error.message)
       })
 
       return result


### PR DESCRIPTION
## Changes

closes: #1217 

- show an error from addToCart response if it's "error level" - everytime
- pushError notification on every broadcasted ERROR event
- do not show success add to cart notification if there is an error with error level in the response


<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
