### PR TITLE
fix(default-theme): set negativePattern to default

### DIFF
--- a/packages/default-theme/src/helpers/index.js
+++ b/packages/default-theme/src/helpers/index.js
@@ -1,15 +1,6 @@
 import dayjs from "dayjs"
 import { PAGE_SEARCH } from "./pages"
 
-const defaultFormatPriceOptions = {
-  pattern: `# !`,
-  negativePattern: `-# !`,
-  separator: ` `,
-  decimal: `,`,
-  symbol: `€`,
-  formatWithSymbol: true,
-}
-
 export { formatPrice } from "@/helpers/formatPrice"
 
 export const getSortingLabel = (sorting) => {

--- a/packages/default-theme/src/helpers/index.js
+++ b/packages/default-theme/src/helpers/index.js
@@ -3,7 +3,7 @@ import { PAGE_SEARCH } from "./pages"
 
 const defaultFormatPriceOptions = {
   pattern: `# !`,
-  negativePattern: `# !`,
+  negativePattern: `-# !`,
   separator: ` `,
   decimal: `,`,
   symbol: `€`,

--- a/packages/default-theme/src/helpers/index.js
+++ b/packages/default-theme/src/helpers/index.js
@@ -3,6 +3,7 @@ import { PAGE_SEARCH } from "./pages"
 
 const defaultFormatPriceOptions = {
   pattern: `# !`,
+  negativePattern: `# !`,
   separator: ` `,
   decimal: `,`,
   symbol: `€`,

--- a/packages/theme-base/dist/helpers/formatPrice.js
+++ b/packages/theme-base/dist/helpers/formatPrice.js
@@ -2,6 +2,7 @@ import currency from "currency.js";
 
 const defaultFormatPriceOptions = {
   pattern: `# !`,
+  negativePattern: `-# !`,
   separator: ` `,
   decimal: `,`,
   symbol: `€`,


### PR DESCRIPTION
## Changes

Set negativePattern to default pattern to have a consistent format, even on negative prices (like promotions)
### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
