### PR TITLE
fix(default-theme): performance issue with css variables duplication

### DIFF
--- a/packages/default-theme/src/assets/scss/main.scss
+++ b/packages/default-theme/src/assets/scss/main.scss
@@ -3,6 +3,12 @@
 
 // Global styles for theme
 
+// Global variables for theme
+#__nuxt {
+  --boxed-mode-max-width: 1366px;
+  --bottom-navigation-height: 3.35rem;
+}
+
 html {
   overflow-x: hidden;
   height: 100vh;

--- a/packages/default-theme/src/assets/scss/variables.scss
+++ b/packages/default-theme/src/assets/scss/variables.scss
@@ -1,12 +1,6 @@
-@import "~@storefront-ui/shared/styles/variables.scss";
+@import "~@storefront-ui/shared/styles/helpers";
 
 $tablet: 768px;
-
-// Global variables for theme
-#__nuxt {
-  --boxed-mode-max-width: 1366px;
-  --bottom-navigation-height: 3.35rem;
-}
 
 @mixin for-tablet {
   @media screen and (min-width: $tablet) {

--- a/packages/default-theme/src/cms/settings.scss
+++ b/packages/default-theme/src/cms/settings.scss
@@ -1,2 +1,1 @@
-@import "@storefront-ui/vue/styles.scss";
 @import "@/assets/scss/variables";

--- a/packages/theme-base/dist/assets/scss/main.scss
+++ b/packages/theme-base/dist/assets/scss/main.scss
@@ -2,6 +2,12 @@
 
 // Global styles for theme
 
+// Global variables for theme
+#__nuxt {
+  --boxed-mode-max-width: 1366px;
+  --bottom-navigation-height: 3.35rem;
+}
+
 html {
   overflow-x: hidden;
   height: 100vh;

--- a/packages/theme-base/dist/assets/scss/variables.scss
+++ b/packages/theme-base/dist/assets/scss/variables.scss
@@ -1,11 +1,5 @@
 $tablet: 768px;
 
-// Global variables for theme
-#__nuxt {
-  --boxed-mode-max-width: 1366px;
-  --bottom-navigation-height: 3.35rem;
-}
-
 @mixin for-tablet {
   @media screen and (min-width: $tablet) {
     @content;


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #1024 
Fixes the perf issue with CSS variables and styles duplication in scoped styles.

In dev mode, it reduced the size of the initial HTML from 494kB -> 291kB
 Before:
![image](https://user-images.githubusercontent.com/13100280/135440624-4030c5ec-c805-4141-8093-968c5358d7a4.png)

After:
![image](https://user-images.githubusercontent.com/13100280/135440599-94d0b799-d11e-4843-9e04-7216977d0736.png)


Reduced around 50kB in production build