### PR TITLE
feat(default-theme): add requested plugin slots

### DIFF
--- a/packages/default-theme/src/components/SwCartProduct.vue
+++ b/packages/default-theme/src/components/SwCartProduct.vue
@@ -24,6 +24,17 @@
         />
       </div>
     </template>
+    <template #price>
+      <div class="sw-collected-product__configuration" v-if="options">
+        <SwPluginSlot name="collected-product-price" :slot-context="product">
+          <SfPrice
+            v-if="regularPrice"
+            :regular="filterPrice(regularPrice)"
+            :special="filterPrice(specialPrice)"
+          />
+        </SwPluginSlot>
+      </div>
+    </template>
     <template #image>
       <SwImage
         v-if="!isPromotion"
@@ -54,11 +65,12 @@
 <script>
 import { getProductMainImageUrl, getProductUrl } from "@shopware-pwa/helpers"
 import { useCart } from "@shopware-pwa/composables"
-import { ref, watch, computed, onMounted } from "@vue/composition-api"
-import { SfCollectedProduct, SfProperty } from "@storefront-ui/vue"
+import { ref, watch, computed } from "@vue/composition-api"
+import { SfCollectedProduct, SfProperty, SfPrice } from "@storefront-ui/vue"
 import getResizedImage from "@/helpers/images/getResizedImage.js"
 import SwImage from "@/components/atoms/SwImage.vue"
 import { usePriceFilter } from "@/logic/usePriceFilter.js"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 
 export default {
   name: "SwCartProduct",
@@ -66,6 +78,8 @@ export default {
     SfCollectedProduct,
     SfProperty,
     SwImage,
+    SfPrice,
+    SwPluginSlot,
   },
   props: {
     product: {
@@ -154,6 +168,7 @@ export default {
   --collected-product-configuration-display: flex;
   --collected-product-padding: var(--spacer-xs);
   --collected-product-background: var(--c-white);
+  --collected-product-title-margin: 0;
   &.sf-collected-product {
     --collected-product-remove-text-display: var(
       --sw-collected-product-remove-btn-display,

--- a/packages/default-theme/src/components/SwProductCard.vue
+++ b/packages/default-theme/src/components/SwProductCard.vue
@@ -1,22 +1,28 @@
 <template>
-  <SfProductCard
-    :title="getName"
-    :image="getImageUrl"
-    :special-price="formatPrice(getSpecialPrice)"
-    :regular-price="formatPrice(getRegularPrice)"
-    :max-rating="5"
-    :score-rating="getProductRating"
-    :image-width="700"
-    :image-height="1000"
-    :link="getRouterLink"
-    class="sw-product-card"
-    :show-add-to-cart-button="true"
-    :is-added-to-cart="isInCart"
-    :is-on-wishlist="isInWishlist"
-    @click:add-to-cart="addToCart"
-    @click:wishlist="toggleWishlistItem"
+  <SwPluginSlot
+    name="product-card"
+    :slot-context="product"
+    style="display: contents"
   >
-  </SfProductCard>
+    <SfProductCard
+      :title="getName"
+      :image="getImageUrl"
+      :special-price="formatPrice(getSpecialPrice)"
+      :regular-price="formatPrice(getRegularPrice)"
+      :max-rating="5"
+      :score-rating="getProductRating"
+      :image-width="700"
+      :image-height="1000"
+      :link="getRouterLink"
+      class="sw-product-card"
+      :show-add-to-cart-button="true"
+      :is-added-to-cart="isInCart"
+      :is-on-wishlist="isInWishlist"
+      @click:add-to-cart="addToCart"
+      @click:wishlist="toggleWishlistItem"
+    >
+    </SfProductCard>
+  </SwPluginSlot>
 </template>
 
 <script>
@@ -34,10 +40,12 @@ import {
 import getResizedImage from "@/helpers/images/getResizedImage.js"
 import { toRefs } from "@vue/composition-api"
 import { usePriceFilter } from "@/logic/usePriceFilter.js"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 
 export default {
   components: {
     SfProductCard,
+    SwPluginSlot,
   },
   setup(props) {
     const { product } = toRefs(props)

--- a/packages/default-theme/src/components/SwProductCardHorizontal.vue
+++ b/packages/default-theme/src/components/SwProductCardHorizontal.vue
@@ -1,18 +1,20 @@
 <template>
-  <SfProductCardHorizontal
-    v-model="quantity"
-    :title="getName"
-    :image="getImageUrl"
-    :special-price="filterPrice(getSpecialPrice)"
-    :regular-price="filterPrice(getRegularPrice)"
-    :max-rating="5"
-    :score-rating="getProductRating"
-    :is-on-wishlist="false"
-    :link="getRouterLink"
-    class="sw-product-card-horizontal"
-    @click:wishlist="toggleWishlist"
-    @click:add-to-cart="addToCart"
-  />
+  <SwPluginSlot name="product-card-horizontal" :slot-context="product">
+    <SfProductCardHorizontal
+      v-model="quantity"
+      :title="getName"
+      :image="getImageUrl"
+      :special-price="filterPrice(getSpecialPrice)"
+      :regular-price="filterPrice(getRegularPrice)"
+      :max-rating="5"
+      :score-rating="getProductRating"
+      :is-on-wishlist="false"
+      :link="getRouterLink"
+      class="sw-product-card-horizontal"
+      @click:wishlist="toggleWishlist"
+      @click:add-to-cart="addToCart"
+    />
+  </SwPluginSlot>
 </template>
 
 <script>
@@ -29,9 +31,10 @@ import {
 } from "@shopware-pwa/helpers"
 import getResizedImage from "@/helpers/images/getResizedImage.js"
 import { usePriceFilter } from "@/logic/usePriceFilter.js"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 
 export default {
-  components: { SfProductCardHorizontal },
+  components: { SfProductCardHorizontal, SwPluginSlot },
   setup(props, { root }) {
     const { addToCart, quantity, getStock, isInCart } = useAddToCart({
       product: props.product,

--- a/packages/default-theme/src/components/SwProductListing.vue
+++ b/packages/default-theme/src/components/SwProductListing.vue
@@ -2,33 +2,35 @@
   <div class="cms-element-product-listing">
     <SfLoader :loading="loading" class="cms-element-product-listing__loader" />
     <div v-if="getElements.length" class="cms-element-product-listing__wrapper">
-      <div
-        tag="div"
-        appear
-        name="cms-element-product-listing__slide"
-        class="cms-element-product-listing__list"
-        :class="{ 'cms-element-product-listing__list--blur': loading }"
-      >
-        <template v-if="!isListView">
-          <SwProductCard
-            v-for="(product, i) in getElements"
-            :key="i + product.id"
-            class="cms-element-product-listing__product-card"
-            :product="product"
-            :style="{ '--index': i }"
-          />
-        </template>
-        <template v-else>
-          <SwProductCardHorizontal
-            v-for="(product, i) in getElements"
-            :key="i + product.id"
-            class="cms-element-product-listing__product-card-horizontal"
-            :product="product"
-            :style="{ '--index': i }"
-          />
-        </template>
-        <div key="holder" class="cms-element-product-listing__place-holder" />
-      </div>
+      <SwPluginSlot name="product-listing" :slot-context="getElements">
+        <div
+          tag="div"
+          appear
+          name="cms-element-product-listing__slide"
+          class="cms-element-product-listing__list"
+          :class="{ 'cms-element-product-listing__list--blur': loading }"
+        >
+          <template v-if="!isListView">
+            <SwProductCard
+              v-for="(product, i) in getElements"
+              :key="i + product.id"
+              class="cms-element-product-listing__product-card"
+              :product="product"
+              :style="{ '--index': i }"
+            />
+          </template>
+          <template v-else>
+            <SwProductCardHorizontal
+              v-for="(product, i) in getElements"
+              :key="i + product.id"
+              class="cms-element-product-listing__product-card-horizontal"
+              :product="product"
+              :style="{ '--index': i }"
+            />
+          </template>
+          <div key="holder" class="cms-element-product-listing__place-holder" />
+        </div>
+      </SwPluginSlot>
       <SfPagination
         v-if="getCurrentPage && !isListView"
         class="cms-element-product-listing__pagination"
@@ -93,6 +95,7 @@ const SwProductCard = () => import("@/components/SwProductCard.vue")
 const SwButton = () => import("@/components/atoms/SwButton.vue")
 const SwProductCardHorizontal = () =>
   import("@/components/SwProductCardHorizontal.vue")
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 
 export default {
   name: "SwProductListing",
@@ -103,6 +106,7 @@ export default {
     SfHeading,
     SfLoader,
     SwButton,
+    SwPluginSlot,
   },
   props: {
     initialListing: {

--- a/packages/default-theme/src/components/checkout/sidebar/SidebarOrderReview.vue
+++ b/packages/default-theme/src/components/checkout/sidebar/SidebarOrderReview.vue
@@ -24,21 +24,23 @@
     <SwPromoCode class="promo-code" />
     <SwTermsAgreementCheckbox />
     <div class="actions">
-      <SwButton
-        class="actions__button color-secondary sw-form__button"
-        data-cy="go-back-to-payment"
-        @click="goToShop"
-      >
-        {{ $t("Go Back to shop") }}
-      </SwButton>
-      <SwButton
-        :disabled="loadings.createOrder"
-        class="actions__button sw-form__button"
-        data-cy="place-my-order"
-        @click="$emit('create-order')"
-      >
-        {{ $t("Place my order") }}
-      </SwButton>
+      <SwPluginSlot name="order-summary-actions">
+        <SwButton
+          class="actions__button color-secondary sw-form__button"
+          data-cy="go-back-to-payment"
+          @click="goToShop"
+        >
+          {{ $t("Go Back to shop") }}
+        </SwButton>
+        <SwButton
+          :disabled="loadings.createOrder"
+          class="actions__button sw-form__button"
+          data-cy="place-my-order"
+          @click="$emit('create-order')"
+        >
+          {{ $t("Place my order") }}
+        </SwButton>
+      </SwPluginSlot>
     </div>
   </div>
 </template>
@@ -52,6 +54,7 @@ import TotalsSummary from "@/components/checkout/summary/TotalsSummary.vue"
 import SwCartProduct from "@/components/SwCartProduct.vue"
 import SwPromoCode from "@/components/SwPromoCode.vue"
 import SwTermsAgreementCheckbox from "@/components/checkout/summary/SwTermsAgreementCheckbox.vue"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 
 export default {
   name: "SidebarOrderReview",
@@ -65,6 +68,7 @@ export default {
     SwCartProduct,
     SfProperty,
     SwTermsAgreementCheckbox,
+    SwPluginSlot,
   },
   data() {
     return {

--- a/packages/default-theme/src/pages/checkout.vue
+++ b/packages/default-theme/src/pages/checkout.vue
@@ -45,18 +45,20 @@
       </div>
       <div class="checkout__aside">
         <transition name="fade">
-          <SidebarOrderSummary
-            v-if="!isLoggedIn"
-            key="order-summary"
-            class="checkout__aside-order"
-            @create-account="invokeRegister"
-          />
-          <SidebarOrderReview
-            v-else
-            key="order-review"
-            class="checkout__aside-order"
-            @create-order="createOrder"
-          />
+          <SwPluginSlot name="order-summary">
+            <SidebarOrderSummary
+              v-if="!isLoggedIn"
+              key="order-summary"
+              class="checkout__aside-order"
+              @create-account="invokeRegister"
+            />
+            <SidebarOrderReview
+              v-else
+              key="order-review"
+              class="checkout__aside-order"
+              @create-order="createOrder"
+            />
+          </SwPluginSlot>
         </transition>
       </div>
     </div>
@@ -104,6 +106,7 @@ import SidebarOrderReview from "@/components/checkout/sidebar/SidebarOrderReview
 import SidebarOrderSummary from "@/components/checkout/sidebar/SidebarOrderSummary.vue"
 import CheckoutSummary from "@/components/checkout/CheckoutSummary.vue"
 import SwErrorsList from "@/components/SwErrorsList.vue"
+import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 
 import {
   PAGE_CHECKOUT,
@@ -123,7 +126,6 @@ import { computed, ref, watch } from "@vue/composition-api"
 import { handlePayment } from "@shopware-pwa/shopware-6-client"
 import SwRegistrationForm from "@/components/forms/SwRegistrationForm.vue"
 import SwButton from "@/components/atoms/SwButton.vue"
-import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
 import { SfHeading, SfLoader } from "@storefront-ui/vue"
 import { useVuelidate } from "@vuelidate/core"
 import SwAlert from "@/components/atoms/SwAlert.vue"


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #1698 
closes #1694

Added following slots:

### product-card
slotContext: product
![image](https://user-images.githubusercontent.com/13100280/136194049-bdbdb370-0c0f-4aca-b027-9f13c4d76650.png)

### product-card-horizontal
slotContext: product
![image](https://user-images.githubusercontent.com/13100280/136194171-6f539b87-4d62-4c92-9913-679c9d98cc53.png)

### product-listing
slotContext: listing elements
![image](https://user-images.githubusercontent.com/13100280/136194314-cd666ed4-13fe-476d-94db-cd04053e269d.png)

### order-summary
slotContext: null
![image](https://user-images.githubusercontent.com/13100280/136194448-5506df61-bce4-4420-9e9a-33b084af7699.png)

### order-summary-actions
slotContext: null
![image](https://user-images.githubusercontent.com/13100280/136194560-357c220a-8cc1-4c39-9a07-f7e9f624dfce.png)

### collected-product-price
slotContext: product
![image](https://user-images.githubusercontent.com/13100280/136194686-2330b2cb-57e4-4715-b7f9-5ca7875e192f.png)







