### PR TITLE
feat(cms): product context for cms elements

### DIFF
--- a/packages/default-theme/src/cms/elements/CmsElementBuyBox.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementBuyBox.vue
@@ -5,7 +5,7 @@
 <script>
 import SwProductDetails from "@/components/SwProductDetails.vue"
 import { useCms } from "@shopware-pwa/composables"
-import { computed } from "@vue/composition-api"
+import { computed, inject } from "@vue/composition-api"
 
 export default {
   components: { SwProductDetails },
@@ -16,11 +16,14 @@ export default {
       default: () => ({}),
     },
   },
-  setup(props) {
+  setup() {
     const { page } = useCms()
+    const cmsProduct = computed(() => page.value?.product)
+
+    const product = inject("cms-product", cmsProduct)
 
     return {
-      product: computed(() => page.value?.product),
+      product,
     }
   },
 }

--- a/packages/default-theme/src/cms/elements/CmsElementBuyBox.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementBuyBox.vue
@@ -17,7 +17,7 @@ export default {
     },
   },
   setup() {
-    const { page } = useCms()
+    const { page } = useCms() // fallback for provide/inject, remove in future
     const cmsProduct = computed(() => page.value?.product)
 
     const product = inject("cms-product", cmsProduct)

--- a/packages/default-theme/src/cms/elements/CmsElementCategoryNavigation.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementCategoryNavigation.vue
@@ -64,7 +64,7 @@
 import { SfList, SfMenuItem, SfHeading, SfChevron } from "@storefront-ui/vue"
 import { getStoreNavigation } from "@shopware-pwa/shopware-6-client"
 import { useCms, getApplicationContext } from "@shopware-pwa/composables"
-import { ref, computed, onMounted } from "@vue/composition-api"
+import { ref, computed, onMounted, inject } from "@vue/composition-api"
 import SwButton from "@/components/atoms/SwButton.vue"
 import SwAccordion from "@/components/organisms/SwAccordion.vue"
 import { getCategoryUrl, getTranslatedProperty } from "@shopware-pwa/helpers"
@@ -89,7 +89,13 @@ export default {
     const { apiInstance } = getApplicationContext({
       contextName: "CmsElementCategoryNavigation",
     })
-    const { resourceIdentifier } = useCms()
+    const { resourceIdentifier: defaultIdentifier } = useCms() // fallback for provide/inject, remove in future
+
+    const cmsPage = inject("cms-page")
+    const resourceIdentifier = computed(
+      () => cmsPage?.value?.resourceIdentifier ?? defaultIdentifier
+    )
+
     const navTitle = ref(root.$t("Subcategories"))
     const navigationElements = ref([])
     const navigation = computed(() => navigationElements.value)

--- a/packages/default-theme/src/cms/elements/CmsElementContactForm.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementContactForm.vue
@@ -138,7 +138,7 @@ import {
   getApplicationContext,
   useCms,
 } from "@shopware-pwa/composables"
-import { computed, reactive, ref, toRefs } from "@vue/composition-api"
+import { computed, reactive, ref, toRefs, inject } from "@vue/composition-api"
 import SwButton from "@/components/atoms/SwButton.vue"
 import { sendContactForm } from "@shopware-pwa/shopware-6-client"
 import SwErrorsList from "@/components/SwErrorsList.vue"
@@ -166,7 +166,13 @@ export default {
       contextName: "CmsElementContactForm",
     })
     const { getSalutations, error: salutationsError } = useSalutations()
-    const { resourceIdentifier } = useCms()
+    const { resourceIdentifier: defaultIdentifier } = useCms() // fallback for provide/inject, remove in future
+
+    const cmsPage = inject("cms-page")
+    const resourceIdentifier = computed(
+      () => cmsPage?.value?.resourceIdentifier ?? defaultIdentifier
+    )
+
     const getMappedSalutations = computed(() =>
       mapSalutations(getSalutations.value)
     )

--- a/packages/default-theme/src/cms/elements/CmsElementImageGallery.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementImageGallery.vue
@@ -4,7 +4,7 @@
 
 <script>
 import SwProductGallery from "@/components/SwProductGallery.vue"
-import { computed } from "@vue/composition-api"
+import { computed, inject } from "@vue/composition-api"
 import { useCms } from "@shopware-pwa/composables"
 
 export default {
@@ -23,9 +23,12 @@ export default {
 
   setup(props) {
     const { page } = useCms()
+    const cmsProduct = computed(() => page.value?.product)
+
+    const product = inject("cms-product", cmsProduct)
 
     return {
-      product: computed(() => page.value?.product),
+      product,
     }
   },
 }

--- a/packages/default-theme/src/cms/elements/CmsElementImageGallery.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementImageGallery.vue
@@ -22,7 +22,7 @@ export default {
   },
 
   setup(props) {
-    const { page } = useCms()
+    const { page } = useCms() // fallback for provide/inject, remove in future
     const cmsProduct = computed(() => page.value?.product)
 
     const product = inject("cms-product", cmsProduct)

--- a/packages/default-theme/src/cms/elements/CmsElementProductDescriptionReviews.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementProductDescriptionReviews.vue
@@ -26,7 +26,7 @@ export default {
     },
   },
   setup(props) {
-    const { page } = useCms()
+    const { page } = useCms() // fallback for provide/inject, remove in future
     const cmsProduct = computed(() => page.value?.product)
 
     const product = inject("cms-product", cmsProduct)

--- a/packages/default-theme/src/cms/elements/CmsElementProductDescriptionReviews.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementProductDescriptionReviews.vue
@@ -13,7 +13,7 @@
 import SwProductDescription from "@/components/SwProductDescription.vue"
 import SwProductTabs from "@/components/SwProductTabs.vue"
 import { useCms } from "@shopware-pwa/composables"
-import { computed } from "@vue/composition-api"
+import { computed, inject } from "@vue/composition-api"
 import { getProductReviews, getProductProperties } from "@shopware-pwa/helpers"
 
 export default {
@@ -27,7 +27,9 @@ export default {
   },
   setup(props) {
     const { page } = useCms()
-    const product = computed(() => page.value?.product)
+    const cmsProduct = computed(() => page.value?.product)
+
+    const product = inject("cms-product", cmsProduct)
 
     const reviews = computed(() =>
       getProductReviews({ product: product.value })

--- a/packages/default-theme/src/components/views/frontend.detail.page.vue
+++ b/packages/default-theme/src/components/views/frontend.detail.page.vue
@@ -31,7 +31,7 @@ import { useUser, useUIState, useDefaults } from "@shopware-pwa/composables"
 import SwGoBackArrow from "@/components/atoms/SwGoBackArrow.vue"
 import SwProductAdvertisement from "@/components/SwProductAdvertisement.vue"
 import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
-import { computed, onMounted, ref } from "@vue/composition-api"
+import { computed, provide } from "@vue/composition-api"
 const SwProductGallery = () => import("@/components/SwProductGallery.vue")
 const SwProductDetails = () => import("@/components/SwProductDetails.vue")
 const SwProductCrossSells = () =>
@@ -67,6 +67,8 @@ export default {
     const { getIncludesConfig } = useDefaults({
       defaultsKey: "useProductListing",
     })
+
+    provide("cms-product", product)
 
     return {
       isLoggedIn,

--- a/packages/theme-base/dist/pages/_.vue
+++ b/packages/theme-base/dist/pages/_.vue
@@ -10,7 +10,7 @@
 </template>
 <script>
 import { useCms } from "@shopware-pwa/composables";
-import { ref } from "vue-demi";
+import { ref, provide } from "vue-demi";
 
 export default {
   name: "DynamicRoute",
@@ -21,6 +21,8 @@ export default {
     const cmsPage = ref(page.value?.cmsPage);
     const staticPage = ref(page.value);
     const staticError = ref(error.value);
+
+    provide("cms-page", page);
 
     const getComponent = () => {
       if (staticPage.value) {


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
This is a request from the plugins side. When you want to provide a product context for CmsPage and not use default useCms composable you couldn't reach correct product context.

### Requirements
When you use `CmsPage` component and want to pass additional product context then you can use `provide` mechanism inside the `setup` function. Example from `frontend.detail.page`:
```ts
provide("cms-product", product)
```

from then child components can use this product
```ts
const product = inject("cms-product")
```
