### PR TITLE
fix(composables): wrong association on product page

### DIFF
--- a/packages/composables/src/internalHelpers/defaultApiParams.json
+++ b/packages/composables/src/internalHelpers/defaultApiParams.json
@@ -17,7 +17,6 @@
         ]
       },
       "productReviews": {},
-      
       "properties": {
         "associations": {
           "group": {}


### PR DESCRIPTION
## Changes
closes: #1705

- error occures only on vv6.4.5.1 of Shopware
- removes obsolete association on useCms search request
(since cross selling products are fetched asynchronously via dedicated endpoint, using that on useCms level is redundand).


<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
