### PR TITLE
fix(cms): inject only cms-page

### DIFF
--- a/packages/default-theme/src/cms/elements/CmsElementBuyBox.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementBuyBox.vue
@@ -18,9 +18,8 @@ export default {
   },
   setup() {
     const { page } = useCms() // fallback for provide/inject, remove in future
-    const cmsProduct = computed(() => page.value?.product)
-
-    const product = inject("cms-product", cmsProduct)
+    const cmsPage = inject("cms-page", page)
+    const product = computed(() => cmsPage.value?.product)
 
     return {
       product,

--- a/packages/default-theme/src/cms/elements/CmsElementCategoryNavigation.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementCategoryNavigation.vue
@@ -89,12 +89,9 @@ export default {
     const { apiInstance } = getApplicationContext({
       contextName: "CmsElementCategoryNavigation",
     })
-    const { resourceIdentifier: defaultIdentifier } = useCms() // fallback for provide/inject, remove in future
-
-    const cmsPage = inject("cms-page")
-    const resourceIdentifier = computed(
-      () => cmsPage?.value?.resourceIdentifier ?? defaultIdentifier.value
-    )
+    const { page } = useCms() // fallback for provide/inject, remove in future
+    const cmsPage = inject("cms-page", page)
+    const resourceIdentifier = computed(() => cmsPage.value?.resourceIdentifier)
 
     const navTitle = ref(root.$t("Subcategories"))
     const navigationElements = ref([])

--- a/packages/default-theme/src/cms/elements/CmsElementContactForm.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementContactForm.vue
@@ -166,12 +166,9 @@ export default {
       contextName: "CmsElementContactForm",
     })
     const { getSalutations, error: salutationsError } = useSalutations()
-    const { resourceIdentifier: defaultIdentifier } = useCms() // fallback for provide/inject, remove in future
-
-    const cmsPage = inject("cms-page")
-    const resourceIdentifier = computed(
-      () => cmsPage?.value?.resourceIdentifier ?? defaultIdentifier.value
-    )
+    const { page } = useCms() // fallback for provide/inject, remove in future
+    const cmsPage = inject("cms-page", page)
+    const resourceIdentifier = computed(() => cmsPage.value?.resourceIdentifier)
 
     const getMappedSalutations = computed(() =>
       mapSalutations(getSalutations.value)

--- a/packages/default-theme/src/cms/elements/CmsElementImageGallery.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementImageGallery.vue
@@ -23,9 +23,8 @@ export default {
 
   setup(props) {
     const { page } = useCms() // fallback for provide/inject, remove in future
-    const cmsProduct = computed(() => page.value?.product)
-
-    const product = inject("cms-product", cmsProduct)
+    const cmsPage = inject("cms-page", page)
+    const product = computed(() => cmsPage.value?.product)
 
     return {
       product,

--- a/packages/default-theme/src/cms/elements/CmsElementProductDescriptionReviews.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementProductDescriptionReviews.vue
@@ -27,9 +27,8 @@ export default {
   },
   setup(props) {
     const { page } = useCms() // fallback for provide/inject, remove in future
-    const cmsProduct = computed(() => page.value?.product)
-
-    const product = inject("cms-product", cmsProduct)
+    const cmsPage = inject("cms-page", page)
+    const product = computed(() => cmsPage.value?.product)
 
     const reviews = computed(() =>
       getProductReviews({ product: product.value })

--- a/packages/default-theme/src/components/views/frontend.detail.page.vue
+++ b/packages/default-theme/src/components/views/frontend.detail.page.vue
@@ -68,8 +68,6 @@ export default {
       defaultsKey: "useProductListing",
     })
 
-    provide("cms-product", product)
-
     return {
       isLoggedIn,
       switchLoginModalState,


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

Injecting `cms-page` for consistency. It contains who;e `cmsPageResponse` so whether the product is inside or not depends on resourceIdentifier.