### PR TITLE
fix(composables): reactivity in local shared state

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "i18n-ally.localesPaths": ["packages/default-theme/src/locales"]
 }

--- a/packages/composables/__tests__/useSharedState.spec.ts
+++ b/packages/composables/__tests__/useSharedState.spec.ts
@@ -18,6 +18,7 @@ describe("Composables - useSharedState", () => {
     rootContextMock.sharedStore = reactive({});
     rootContextMock.isServer = false;
     serverPrefetchMethods = [];
+    rootContextMock.devtools = null;
 
     mockedCompositionAPI.getCurrentInstance.mockImplementation(
       () => rootContextMock
@@ -174,14 +175,12 @@ describe("Composables - useSharedState", () => {
         expect(result.value).toEqual("test value");
       });
 
-      it("should modify value from rootContext in CSR", () => {
+      it("should not modify value from rootContext in CSR", () => {
         const { sharedRef } = useSharedState();
         const result = sharedRef<string>("test-modify-key");
         expect(result.value).toBeNull();
         result.value = "my local change";
-        expect(rootContextMock.sharedStore["test-modify-key"]).toEqual(
-          "my local change"
-        );
+        expect(rootContextMock.sharedStore["test-modify-key"]).toBeUndefined();
       });
 
       it("should preserve the state locally", () => {
@@ -190,9 +189,25 @@ describe("Composables - useSharedState", () => {
         const result2 = sharedRef("test-preserve-key");
         result.value = "changed value";
         expect(result2.value).toEqual("changed value");
-        expect(rootContextMock.sharedStore["test-preserve-key"]).toEqual(
-          "changed value"
-        );
+        expect(
+          rootContextMock.sharedStore["test-preserve-key"]
+        ).toBeUndefined();
+      });
+
+      it("should broadcast message to devtools about the state change", () => {
+        rootContextMock.devtools = {
+          _internal: {
+            updateSharedState: jest.fn(),
+          },
+        };
+
+        const { sharedRef } = useSharedState();
+        const result = sharedRef("test-devtools-broadcast");
+        result.value = "changed value";
+        result.value = "another changed value";
+        expect(
+          rootContextMock.devtools._internal.updateSharedState
+        ).toBeCalledTimes(2);
       });
     });
 


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #1727

Fix reactivity issues, when the new reactivity keys were added after the initial page render (for example on page change). The `reactive` object does not allow to dynamically add new keys. This PR fixed the issue.