### PR TITLE
fix(default theme):  synchronise tabs after switching between them

### DIFF
--- a/packages/nuxt-module/plugins/api-client.js
+++ b/packages/nuxt-module/plugins/api-client.js
@@ -22,8 +22,15 @@ export default async ({ app }, inject) => {
   if (!app.$cookies) {
     throw "Error cookie-universal-nuxt module is not applied in nuxt.config.js";
   }
-  const contextToken = app.$cookies.get("sw-context-token") || "";
-  const languageId = app.$cookies.get("sw-language-id") || "";
+
+  function getCookiesConfig(app) {
+    return {
+      contextToken: app.$cookies.get("sw-context-token") || "",
+      languageId: app.$cookies.get("sw-language-id") || "",
+    };
+  }
+
+  const { contextToken, languageId } = getCookiesConfig(app);
 
   /**
    * Setup Shopware API client
@@ -93,6 +100,16 @@ export default async ({ app }, inject) => {
       refreshUser();
       const { refreshCart } = useCart();
       refreshCart();
+
+      document.addEventListener("visibilitychange", (activeInfo) => {
+        const { contextToken, languageId } = getCookiesConfig(app);
+        if (document.visibilityState === "visible") {
+          instance.update({ contextToken, languageId });
+          refreshSessionContext();
+          refreshUser();
+          refreshCart();
+        }
+      });
     }
     return result;
   };

--- a/packages/nuxt-module/plugins/api-client.js
+++ b/packages/nuxt-module/plugins/api-client.js
@@ -5,6 +5,7 @@ import {
   useSessionContext,
   createShopware,
   ShopwareVuePlugin,
+  useIntercept,
 } from "@shopware-pwa/composables";
 import { reactive, isVue2, Vue2 } from "vue-demi";
 
@@ -100,6 +101,7 @@ export default async ({ app }, inject) => {
       refreshUser();
       const { refreshCart } = useCart();
       refreshCart();
+      const { broadcast } = useIntercept();
 
       document.addEventListener("visibilitychange", (activeInfo) => {
         const { contextToken, languageId } = getCookiesConfig(app);
@@ -108,6 +110,7 @@ export default async ({ app }, inject) => {
           refreshSessionContext();
           refreshUser();
           refreshCart();
+          broadcast("tab-visible");
         }
       });
     }


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

After switching between tabs there was a problem with the synchronisation of the session and card.
For example:
1. go to page
2. open new tam and login
3. go back to page

same with logout


This is the fix for these situations, every time user goes back to the tab we refresh the session and card info to keep that in sync. Additionally, we send interceptor event so you can do additional stuff when it happens using
```
const { on } = useIntercept()

on({
  broadcastKey: 'tab-visible',
  name: "show-console-message",
  handler: () => {
    console.log('Welcome back!')
  },
})
```

![image](https://user-images.githubusercontent.com/13100280/147065177-21ac8d0f-7fc5-47b4-acb1-8af57e2ff7c2.png)
