### PR TITLE
fix(default-theme): SwTopNaviation visibleCategories null variable

### DIFF
--- a/packages/default-theme/src/components/SwTopNavigation.vue
+++ b/packages/default-theme/src/components/SwTopNavigation.vue
@@ -3,7 +3,7 @@
     ref="navigation"
     class="sw-top-navigation"
     data-cy="top-navigation"
-    v-if="visibleCategories.length"
+    v-if="visibleCategories && visibleCategories.length"
   >
     <SwPluginSlot name="sw-top-navigation-before" />
     <div


### PR DESCRIPTION
VisibleCategories of SwTopNaviation is sometimes null, for example when switching from checkout to home, by clicking the logo. The issue should be fixed after this change.