### PR TITLE
feat(cli): remove devMode question from plugins command

### DIFF
--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -31,17 +31,10 @@ module.exports = {
         footer: process.env.ADMIN_PASSWORD && "password from .env is hidden",
       };
 
-      const devModeQuestion = !inputParameters.devMode && {
-        type: "confirm",
-        name: "devMode",
-        message:
-          "Do you want to allow dev mode for slots? (Don't use for production!)",
-      };
 
       const answers = await toolbox.prompt.ask([
         shopwareUsernameQuestion,
         shopwarePasswordQuestion,
-        devModeQuestion,
       ]);
       Object.assign(inputParameters, answers);
     }


### PR DESCRIPTION
## Changes
Removes the question 
```
Do you want to allow dev mode for slots? (Don't use for production!)
```

as it is hard for new members to answer that. Advanced users can still access that by invoking `yarn shopware-pwa plugins --devMode` but our recommendation would be to use VueDevtools to discover plugin slots

![image](https://user-images.githubusercontent.com/13100280/149144444-d0ccae8c-9d78-49d1-9118-812fce4f7e54.png)
