### PR TITLE
fix(cli): do not remove @shopware-pwa packages

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -97,16 +97,6 @@ module.exports = {
       config.dependencies = config.dependencies || {};
       config.devDependencies = config.devDependencies || {};
 
-      // remove all @shopware-pwa packages
-      const shopwarePwaPackageNames = Object.keys({
-        ...config.dependencies,
-        ...config.devDependencies,
-      }).filter((name) => name.includes("@shopware-pwa"));
-      shopwarePwaPackageNames.forEach((packageName) => {
-        delete config.dependencies[packageName];
-        delete config.devDependencies[packageName];
-      });
-
       if (!isLocalSetup) {
         // add dependencies with version
         coreDevPackages.forEach((packageName) => {


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

closes #1789

we shouldn't remove @shopware-pwa packages if there're already some of them installed manually. Just update the version of nuxt-module which should be the same as CLI version.

originally proposed solution: #1790 - shoutout to @stigvanbrabant for pointing the problem