### PR TITLE
feat(nuxt-module): add parsing of "forwarded" header when checking for valid domains

### DIFF
--- a/packages/nuxt-module/package.json
+++ b/packages/nuxt-module/package.json
@@ -33,6 +33,7 @@
     "chokidar": "^3.5.2",
     "cookie-universal": "^2.1.5",
     "cosmiconfig": "^7.0.1",
+    "forwarded-parse": "^2.1.2",
     "fs-extra": "^10.0.0",
     "fs-jetpack": "^4.3.0",
     "he": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7363,6 +7363,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+forwarded-parse@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz#08511eddaaa2ddfd56ba11138eee7df117a09325"
+  integrity sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"


### PR DESCRIPTION
## Changes

right now only the `X-Forwarded-Host` header is checked when getting the right domain config.
Sadly that wont work in AWS with ALB, there exists the `Forwarded` Header now (Symfony can already deal with that)
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded

If present we take this header into account instead of fallback to the internal host (ip) when the `X-Forwarded-Host` header is missing.

### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
