### PR TITLE
fix(nuxt module): redirect 302 issue on apple devices

### DIFF
--- a/packages/nuxt-module/plugins/api-client.js
+++ b/packages/nuxt-module/plugins/api-client.js
@@ -23,6 +23,27 @@ export default async ({ app }, inject) => {
   if (!app.$cookies) {
     throw "Error cookie-universal-nuxt module is not applied in nuxt.config.js";
   }
+  
+  /**
+   * get contextToken from localStorage when cookie lost in redirects
+   */
+   if (process.client && !app.$cookies.get("sw-context-token")) {
+    if (typeof localStorage !== undefined) {
+      try {
+        app.$cookies.set(
+          "sw-context-token",
+          localStorage.getItem("sw-context-token"),
+          {
+            maxAge: 60 * 60 * 24 * 365,
+            sameSite: "Lax",
+            path: "/",
+          }
+        )
+      } finally {
+        localStorage.removeItem("sw-context-token")
+      }
+    }
+  }
 
   function getCookiesConfig(app) {
     return {

--- a/packages/nuxt-module/plugins/api-client.js
+++ b/packages/nuxt-module/plugins/api-client.js
@@ -28,7 +28,7 @@ export default async ({ app }, inject) => {
    * get contextToken from localStorage when cookie lost in redirects
    */
   if (process.client) {
-    if (!app.$cookies.get("sw-context-token")) {
+    if (!app.$cookies.get("sw-context-token") && typeof localStorage !== "undefined") {
       app.$cookies.set(
         "sw-context-token",
         localStorage.getItem("sw-context-token"),

--- a/packages/nuxt-module/plugins/api-client.js
+++ b/packages/nuxt-module/plugins/api-client.js
@@ -27,22 +27,19 @@ export default async ({ app }, inject) => {
   /**
    * get contextToken from localStorage when cookie lost in redirects
    */
-   if (process.client && !app.$cookies.get("sw-context-token")) {
-    if (typeof localStorage !== undefined) {
-      try {
-        app.$cookies.set(
-          "sw-context-token",
-          localStorage.getItem("sw-context-token"),
-          {
-            maxAge: 60 * 60 * 24 * 365,
-            sameSite: "Lax",
-            path: "/",
-          }
-        )
-      } finally {
-        localStorage.removeItem("sw-context-token")
-      }
+  if (process.client) {
+    if (!app.$cookies.get("sw-context-token")) {
+      app.$cookies.set(
+        "sw-context-token",
+        localStorage.getItem("sw-context-token"),
+        {
+          maxAge: 60 * 60 * 24 * 365,
+          sameSite: "Lax",
+          path: "/",
+        }
+      )
     }
+    localStorage.removeItem("sw-context-token")
   }
 
   function getCookiesConfig(app) {

--- a/packages/nuxt-module/plugins/api-client.js
+++ b/packages/nuxt-module/plugins/api-client.js
@@ -28,7 +28,7 @@ export default async ({ app }, inject) => {
    * get contextToken from sessionStorage when cookie lost in redirects
    * https://github.com/vuestorefront/shopware-pwa/pull/1817
    */
-  if (process.client && navigator.userAgent.indexOf('WebKit')) {
+  if (process.client && navigator?.userAgent.includes('WebKit')) {
     if (!app.$cookies.get("sw-context-token") && typeof sessionStorage !== "undefined") {
       app.$cookies.set(
         "sw-context-token",

--- a/packages/nuxt-module/plugins/api-client.js
+++ b/packages/nuxt-module/plugins/api-client.js
@@ -25,13 +25,14 @@ export default async ({ app }, inject) => {
   }
   
   /**
-   * get contextToken from localStorage when cookie lost in redirects
+   * get contextToken from sessionStorage when cookie lost in redirects
+   * https://github.com/vuestorefront/shopware-pwa/pull/1817
    */
-  if (process.client) {
-    if (!app.$cookies.get("sw-context-token") && typeof localStorage !== "undefined") {
+  if (process.client && navigator.userAgent.indexOf('WebKit')) {
+    if (!app.$cookies.get("sw-context-token") && typeof sessionStorage !== "undefined") {
       app.$cookies.set(
         "sw-context-token",
-        localStorage.getItem("sw-context-token"),
+        sessionStorage.getItem("sw-context-token"),
         {
           maxAge: 60 * 60 * 24 * 365,
           sameSite: "Lax",
@@ -39,7 +40,7 @@ export default async ({ app }, inject) => {
         }
       )
     }
-    localStorage.removeItem("sw-context-token")
+    sessionStorage.removeItem("sw-context-token")
   }
 
   function getCookiesConfig(app) {

--- a/packages/shopware-6-client/src/services/checkoutService.ts
+++ b/packages/shopware-6-client/src/services/checkoutService.ts
@@ -54,9 +54,15 @@ export async function handlePayment(
   if (!params?.orderId) {
     throw new Error("handlePayment method requires orderId");
   }
-
-  if (typeof localStorage !== "undefined") {
-    localStorage.setItem("sw-context-token", contextInstance?.config?.contextToken as string)
+  
+   /**
+   * save contextToken in sessionStorage when using Webkit
+   * https://github.com/vuestorefront/shopware-pwa/pull/1817
+   */
+  if(navigator.userAgent.indexOf('WebKit')){
+    if (typeof sessionStorage !== "undefined") {
+      sessionStorage.setItem("sw-context-token", contextInstance?.config?.contextToken as string)
+    }
   }
 
   const resp = await contextInstance.invoke.get(

--- a/packages/shopware-6-client/src/services/checkoutService.ts
+++ b/packages/shopware-6-client/src/services/checkoutService.ts
@@ -55,6 +55,10 @@ export async function handlePayment(
     throw new Error("handlePayment method requires orderId");
   }
 
+  if (typeof localStorage !== undefined) {
+    localStorage.setItem("sw-context-token", contextInstance?.config?.contextToken as string)
+  }
+
   const resp = await contextInstance.invoke.get(
     handlePaymentEndpoint(),
     {

--- a/packages/shopware-6-client/src/services/checkoutService.ts
+++ b/packages/shopware-6-client/src/services/checkoutService.ts
@@ -59,7 +59,7 @@ export async function handlePayment(
    * save contextToken in sessionStorage when using Webkit
    * https://github.com/vuestorefront/shopware-pwa/pull/1817
    */
-  if(navigator.userAgent.indexOf('WebKit')){
+  if(navigator?.userAgent.includes('WebKit')){
     if (typeof sessionStorage !== "undefined") {
       sessionStorage.setItem("sw-context-token", contextInstance?.config?.contextToken as string)
     }

--- a/packages/shopware-6-client/src/services/checkoutService.ts
+++ b/packages/shopware-6-client/src/services/checkoutService.ts
@@ -55,7 +55,7 @@ export async function handlePayment(
     throw new Error("handlePayment method requires orderId");
   }
 
-  if (typeof localStorage !== undefined) {
+  if (typeof localStorage !== "undefined") {
     localStorage.setItem("sw-context-token", contextInstance?.config?.contextToken as string)
   }
 


### PR DESCRIPTION
## Files
-- packages/shopware-6-client/src/services/checkoutService.ts
-- packages/nuxt-module/plugins/api-client.js

## Changes
-- Added a checker for localStorage item `sw-context-token` when `sw-context-token` cookie was lost in 302 redirect.
-- added a setter for localStorage item `sw-context-token` when redirected to external payment provider.
-- closes #1638 

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
