### PR TITLE
Adjust SearchCriteria interface

### DIFF
--- a/packages/commons/interfaces/search/SearchCriteria.ts
+++ b/packages/commons/interfaces/search/SearchCriteria.ts
@@ -9,6 +9,7 @@ import { Aggregation } from "./Aggregation";
 import { TotalCountMode } from "./TotalCountMode";
 import { ShopwareAssociation } from "./Association";
 import { Grouping } from "./Grouping";
+import { StoreSort } from "./StoreSort";
 
 /**
  * @public
@@ -33,7 +34,6 @@ export interface Includes {
 export interface SearchCriteria {
   filters?: Array<EqualsFilter | EqualsAnyFilter | RangeFilter | MultiFilter>;
   pagination?: Pagination;
-  //
   sort?: Sort | Sort[];
   term?: string;
   manufacturer?: string[];
@@ -53,17 +53,21 @@ export interface SearchCriteria {
  * @beta
  */
 export type ShopwareSearchParams = {
-  p?: number | undefined;
+  page?: number | undefined;
   limit?: number | undefined;
+  filter?: Array<EqualsFilter | EqualsAnyFilter | RangeFilter | MultiFilter> | undefined;
+  sort?: Array<StoreSort> | undefined;
+  postFilter?:  Array<EqualsFilter | EqualsAnyFilter | RangeFilter | MultiFilter> | undefined;
+  associations?: ShopwareAssociation;
+  aggregations?: Array<Aggregation> | undefined;
+  grouping?: Array<Grouping>;
+
   /**
-   *  @deprecated use order property instead
+   *  Not mentioned in the store-api docs
    */
-  sort?: string | undefined;
   order?: string | undefined;
   term?: string | undefined;
   ids?: string[];
-  associations?: ShopwareAssociation;
-  grouping?: Grouping;
   properties?: string | undefined | never[];
   manufacturer?: string | undefined | never[];
   includes?: Includes;

--- a/packages/commons/interfaces/search/StoreSort.ts
+++ b/packages/commons/interfaces/search/StoreSort.ts
@@ -1,0 +1,5 @@
+export interface StoreSort {
+    field: string;
+    order: string;
+    naturalSorting: boolean;
+}


### PR DESCRIPTION
## Changes
Closes #1811

Using [these docs](https://shopware.stoplight.io/docs/store-api/c2NoOjEwOTgzNTU0), I updated `ShopwareSearchParams` interact in `packages/commons/interfaces/search/SearchCriteria.ts`. When it comes to additional parameters, I put them at the end of the interface and signalized that with a comment. 

Initial description:
`store-api` has its own Criteria. The set of parameters that can be used for specific endpoints. The global Search Criteria, internally named as [ShopwareSearchParams](https://github.com/vuestorefront/shopware-pwa/blob/master/packages/commons/interfaces/search/SearchCriteria.ts#L55) seem to be outdated.

<!-- Describe the changes which you did and which issue you're closing
-->

<!-- Paste here screenshot if there are visual changes -->

### Checklist
- [ ] fix outdated tests
- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines