### PR TITLE
fix(nuxt-module): accept nuxt plugin mode from filename

### DIFF
--- a/api/composables.api.md
+++ b/api/composables.api.md
@@ -867,7 +867,7 @@ export function useBreadcrumbs(params?: {
 export function useCart(): IUseCart;
 
 // @beta
-export function useCartItem({ cartItem }: {
+export function useCartItem({ cartItem, }: {
     cartItem: LineItem;
 }): IUseCartItem;
 

--- a/docs/landing/resources/api/composables.md
+++ b/docs/landing/resources/api/composables.md
@@ -17,7 +17,7 @@ Vue's composables to be used in Shopware frontend application.
 |  [useAddToCart(params)](./composables.useaddtocart.md) | <b><i>(BETA)</i></b> Add product to cart. Options - [IUseAddToCart](./composables.iuseaddtocart.md) |
 |  [useBreadcrumbs(params)](./composables.usebreadcrumbs.md) | <b><i>(BETA)</i></b> Composable for displaying and setting breadcrumbs for page. |
 |  [useCart()](./composables.usecart.md) | <b><i>(BETA)</i></b> Composable for cart management. Options - [IUseCart](./composables.iusecart.md) |
-|  [useCartItem({ cartItem })](./composables.usecartitem.md) | <b><i>(BETA)</i></b> Composable for cart item management. Options - [IUseCartItem](./composables.iusecartitem.md) |
+|  [useCartItem({ cartItem, })](./composables.usecartitem.md) | <b><i>(BETA)</i></b> Composable for cart item management. Options - [IUseCartItem](./composables.iusecartitem.md) |
 |  [useCheckout()](./composables.usecheckout.md) | <b><i>(BETA)</i></b> Composable for Checkout management. Options - [IUseCheckout](./composables.iusecheckout.md) |
 |  [useCms(params)](./composables.usecms.md) | <b><i>(BETA)</i></b> |
 |  [useCountries()](./composables.usecountries.md) | <b><i>(BETA)</i></b> |

--- a/docs/landing/resources/api/composables.usecartitem.md
+++ b/docs/landing/resources/api/composables.usecartitem.md
@@ -12,7 +12,7 @@ Composable for cart item management. Options - [IUseCartItem](./composables.iuse
 <b>Signature:</b>
 
 ```typescript
-export declare function useCartItem({ cartItem }: {
+export declare function useCartItem({ cartItem, }: {
     cartItem: LineItem;
 }): IUseCartItem;
 ```
@@ -21,7 +21,7 @@ export declare function useCartItem({ cartItem }: {
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  { cartItem } | { cartItem: LineItem; } |  |
+|  { cartItem, } | { cartItem: LineItem; } |  |
 
 <b>Returns:</b>
 

--- a/packages/composables/__tests__/useCart.spec.ts
+++ b/packages/composables/__tests__/useCart.spec.ts
@@ -460,7 +460,7 @@ describe("Composables - useCart", () => {
         stateCart.value = {
           lineItems: [
             { quantity: 3, type: "product", referencedId: "some-item-id" },
-            { referencedId: ""}
+            { referencedId: "" },
           ],
         };
         const { getProductItemsSeoUrlsData } = useCart();

--- a/packages/composables/__tests__/useCartItem.spec.ts
+++ b/packages/composables/__tests__/useCartItem.spec.ts
@@ -25,7 +25,6 @@ jest.mock("@shopware-pwa/helpers");
 import { useCartItem } from "../src/logic/useCartItem";
 
 describe("Composables - useCart", () => {
- 
   const stateCart: Ref<Object | null> = ref(null);
   const rootContextMock: any = {
     $shopwareApiInstance: jest.fn(),
@@ -41,9 +40,9 @@ describe("Composables - useCart", () => {
     mockedComposables.useCart.mockImplementation(() => {
       return {
         refreshCart: jest.fn(),
-        broadcastUpcomingErrors: broadcastUpcomingErrorsMocked
-      } as any
-    })
+        broadcastUpcomingErrors: broadcastUpcomingErrorsMocked,
+      } as any;
+    });
 
     mockedComposables.useDefaults.mockImplementation(() => {
       return {
@@ -73,288 +72,287 @@ describe("Composables - useCart", () => {
   });
   describe("general", () => {
     it("should throw an error on missing cartItem in constructor", () => {
-      expect(() => useCartItem({} as any)).toThrow("[useCartItem] mandatory cartItem argument is missing.")
-    })
-  })
+      expect(() => useCartItem({} as any)).toThrow(
+        "[useCartItem] mandatory cartItem argument is missing."
+      );
+    });
+  });
   describe("computed", () => {
     describe("lineItem", () => {
       it("should return computed property made of provided lineItem in constructor", () => {
-        const { lineItem} = useCartItem({
+        const { lineItem } = useCartItem({
           cartItem: {
-            id: "some-cart-item"
-          } as any
-        })
+            id: "some-cart-item",
+          } as any,
+        });
         expect(lineItem.value).toStrictEqual({
-          id: "some-cart-item"
-        })
-      })
-    })
+          id: "some-cart-item",
+        });
+      });
+    });
     describe("itemQuantity", () => {
       it("should return item quantity", () => {
         const cartItem = {
-          quantity: 10
-        }
+          quantity: 10,
+        };
         const { itemQuantity } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemQuantity.value).toStrictEqual(10);
-      })
-    })
+      });
+    });
     describe("itemImageThumbnailUrl", () => {
       it("should invoke specific helper and return correct cover url", () => {
         const { itemImageThumbnailUrl } = useCartItem({
-          cartItem: {}
-        } as any)
-        mockedHelpers.getProductMainImageUrl.mockReturnValue("https://some.url/image.png")
+          cartItem: {},
+        } as any);
+        mockedHelpers.getProductMainImageUrl.mockReturnValue(
+          "https://some.url/image.png"
+        );
 
         expect(itemImageThumbnailUrl.value).toBe("https://some.url/image.png");
         expect(mockedHelpers.getProductMainImageUrl).toBeCalledTimes(1);
-      })
-
-    })
+      });
+    });
     describe("itemRegularPrice", () => {
       it("should return item regular price based on list price", () => {
         const cartItem = {
           price: {
             listPrice: {
-              price: 59.90
-            }
-          }
-        }
+              price: 59.9,
+            },
+          },
+        };
         const { itemRegularPrice } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemRegularPrice.value).toStrictEqual(59.9);
-      })
+      });
 
       it("should return undefined based on list price if object does not exist", () => {
-        const cartItem = {
-         
-        }
+        const cartItem = {};
         const { itemRegularPrice } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemRegularPrice.value).toBeUndefined();
-      })
+      });
 
       it("should return item regular price based on unit price", () => {
         const cartItem = {
           price: {
-            unitPrice: 59.90
-            
-          }
-        }
+            unitPrice: 59.9,
+          },
+        };
         const { itemRegularPrice } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemRegularPrice.value).toStrictEqual(59.9);
-      })
-
-    })
+      });
+    });
     describe("itemSpecialPrice", () => {
       it("should return item special price", () => {
         const cartItem = {
           price: {
-              listPrice: 59.90,
-              unitPrice: 59.90
-            
-          }
-        }
+            listPrice: 59.9,
+            unitPrice: 59.9,
+          },
+        };
         const { itemSpecialPrice } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
-        expect(itemSpecialPrice.value).toStrictEqual(59.90);
-      })
+        expect(itemSpecialPrice.value).toStrictEqual(59.9);
+      });
       it("should return undefined instead a special price if listprice or price does not exist", () => {
         const cartItem = {
           price: {
-            listPrice: undefined
-          }
-        }
+            listPrice: undefined,
+          },
+        };
         const { itemSpecialPrice } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemSpecialPrice.value).toBeUndefined();
-      })
+      });
       it("should return undefined instead a special price if listprice or price does not exist", () => {
         const cartItem = {
-          price: undefined
-        }
+          price: undefined,
+        };
         const { itemSpecialPrice } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemSpecialPrice.value).toBeUndefined();
-      })
-
-    })
+      });
+    });
     describe("itemStock", () => {
       it("should return stock if deliveryInformation is included in the response", () => {
         const cartItem = {
           deliveryInformation: {
-            stock: 123
-          }
-        }
+            stock: 123,
+          },
+        };
         const { itemStock } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemStock.value).toBe(123);
-      })
+      });
       it("should return undefined if deliveryInformation is not included in the response", () => {
         const cartItem = {
-          deliveryInformation:undefined
-        }
+          deliveryInformation: undefined,
+        };
         const { itemStock } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemStock.value).toBeUndefined();
-      })
-    })
+      });
+    });
     describe("itemOptions", () => {
       it("should return product options if item has product type", () => {
         const cartItem = {
           payload: {
             options: ["option-1"],
           },
-          type: "product"
-        }
+          type: "product",
+        };
         const { itemOptions } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemOptions.value).toStrictEqual(["option-1"]);
-      })
+      });
 
       it("should return an empty array if item is not in product type", () => {
         const cartItem = {
           payload: {
             options: ["option-1"],
           },
-          type: "promotion"
-        }
+          type: "promotion",
+        };
         const { itemOptions } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemOptions.value).toStrictEqual([]);
-      })
+      });
 
       it("should return an empty array if item has no payload object", () => {
         const cartItem = {
           payload: undefined,
-          type: "product"
-        }
+          type: "product",
+        };
         const { itemOptions } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemOptions.value).toStrictEqual([]);
-      })
-
-    })
+      });
+    });
 
     describe("itemType", () => {
       it("should return item type", () => {
         const cartItem = {
-          type: "promotion"
-        }
+          type: "promotion",
+        };
         const { itemType } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(itemType.value).toStrictEqual("promotion");
-      })
-
-    })
+      });
+    });
     describe("isProduct", () => {
       it("should return true in case if item type is a product", () => {
         const cartItem = {
-          type: "product"
-        }
+          type: "product",
+        };
         const { isProduct } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(isProduct.value).toStrictEqual(true);
-      })
-
-    })
+      });
+    });
 
     describe("isPromotion", () => {
       it("should return true in case if item type is a promotion", () => {
         const cartItem = {
-          type: "promotion"
-        }
+          type: "promotion",
+        };
         const { isPromotion } = useCartItem({
-          cartItem
-        } as any)
+          cartItem,
+        } as any);
 
         expect(isPromotion.value).toStrictEqual(true);
-      })
-
-    })
-
+      });
+    });
   });
   describe("methods", () => {
     describe("removeItem", () => {
       it("should invoke removeCartItem from @shopware-pwa/shopware-6-client package", async () => {
         const { removeItem } = useCartItem({
           cartItem: {
-          id: "itemId",
-          referencedId: "itemId"
-          } as any
+            id: "itemId",
+            referencedId: "itemId",
+          } as any,
         });
         await removeItem();
         expect(mockedShopwareClient.removeCartItem).toBeCalledWith(
-          "itemId", expect.any(Function)
-        )
+          "itemId",
+          expect.any(Function)
+        );
       });
     });
     describe("changeItemQuantity", () => {
       it("should invoke changeCartItemQuantity from @shopware-pwa/shopware-6-client package", async () => {
         const { changeItemQuantity } = useCartItem({
           cartItem: {
-          id: "itemId",
-          referencedId: "itemId"
-          } as any
+            id: "itemId",
+            referencedId: "itemId",
+          } as any,
         });
         await changeItemQuantity(5);
         expect(mockedShopwareClient.changeCartItemQuantity).toBeCalledWith(
-          "itemId", 5, expect.any(Function)
-        )
+          "itemId",
+          5,
+          expect.any(Function)
+        );
       });
     });
     describe("getProductItemSeoUrlData", () => {
       it("should invoke getProducts from @shopware-pwa/shopware-6-client package", async () => {
         const { getProductItemSeoUrlData } = useCartItem({
           cartItem: {
-          id: "itemId",
-          referencedId: "itemId"
-          } as any
+            id: "itemId",
+            referencedId: "itemId",
+          } as any,
         });
         await getProductItemSeoUrlData();
         expect(mockedShopwareClient.getProduct).toBeCalledWith(
-          "itemId", {"associations": {"seoUrls": {}}, "includes": {"product": ["id", "seoUrls"], "seo_url": ["seoPathInfo"]}}, expect.any(Function)
-        )
+          "itemId",
+          {
+            associations: { seoUrls: {} },
+            includes: { product: ["id", "seoUrls"], seo_url: ["seoPathInfo"] },
+          },
+          expect.any(Function)
+        );
       });
       it("should not invoke getProducts method in case the referencedId does not exist", async () => {
         const { getProductItemSeoUrlData } = useCartItem({
           cartItem: {
-          id: "itemId"
-          } as any
+            id: "itemId",
+          } as any,
         });
         await getProductItemSeoUrlData();
-        expect(mockedShopwareClient.getProduct).not.toBeCalled()
+        expect(mockedShopwareClient.getProduct).not.toBeCalled();
       });
     });
   });
-  
 });

--- a/packages/composables/__tests__/useCms.spec.ts
+++ b/packages/composables/__tests__/useCms.spec.ts
@@ -180,8 +180,8 @@ describe("Composables - useCms", () => {
         const { search, page } = useCms();
         let invocationCriteria: any = null;
         const mockedParams = {
-          limit: 50
-        }
+          limit: 50,
+        };
         mockedHelpers._parseUrlQuery.mockReturnValueOnce(mockedParams as any);
         mockedGetPage.getCmsPage.mockImplementationOnce(
           async (path: string, searchCriteria, apiInstance): Promise<any> => {
@@ -197,7 +197,6 @@ describe("Composables - useCms", () => {
           rootContextMock.apiInstance
         );
         expect(invocationCriteria?.limit).toEqual(50);
-
       });
 
       it("should provide default includes if not provided, but configuration exist", async () => {
@@ -233,8 +232,8 @@ describe("Composables - useCms", () => {
         );
         const searchParams = {
           includes: { product: ["someCustomField"] },
-        }
-        mockedHelpers._parseUrlQuery.mockReturnValueOnce(searchParams as any)
+        };
+        mockedHelpers._parseUrlQuery.mockReturnValueOnce(searchParams as any);
         expect(page.value).toEqual(null);
         await search("", searchParams);
         expect(mockedGetPage.getCmsPage).toBeCalledWith(

--- a/packages/composables/__tests__/useOrderDetails.spec.ts
+++ b/packages/composables/__tests__/useOrderDetails.spec.ts
@@ -94,7 +94,7 @@ describe("Composables - useOrderDetails", () => {
         deliveries: [
           {
             shippingOrderAddress: {
-              id: "delivery-address-id"
+              id: "delivery-address-id",
             },
             shippingMethod: {
               name: "Express",

--- a/packages/composables/src/hooks/useCart/index.ts
+++ b/packages/composables/src/hooks/useCart/index.ts
@@ -166,9 +166,9 @@ export function useCart(): IUseCart {
     try {
       const result = await getProducts(
         {
-          ids: cartItems.value.map(
-            ({ referencedId }) => referencedId
-          ).filter(String) as string[],
+          ids: cartItems.value
+            .map(({ referencedId }) => referencedId)
+            .filter(String) as string[],
           includes: (getDefaults() as any).getProductItemsSeoUrlsData.includes,
           associations: (getDefaults() as any).getProductItemsSeoUrlsData
             .associations,
@@ -243,6 +243,6 @@ export function useCart(): IUseCart {
     subtotal,
     cartErrors,
     getProductItemsSeoUrlsData,
-    broadcastUpcomingErrors
+    broadcastUpcomingErrors,
   };
 }

--- a/packages/composables/src/logic/useCartItem.ts
+++ b/packages/composables/src/logic/useCartItem.ts
@@ -7,17 +7,16 @@ import {
 import {
   Product,
   LineItem,
-  LineItemType
+  LineItemType,
 } from "@shopware-pwa/commons/interfaces";
 import {
   getApplicationContext,
   useDefaults,
-  useCart
+  useCart,
 } from "@shopware-pwa/composables";
 
-import { getProductMainImageUrl } from "@shopware-pwa/helpers"
+import { getProductMainImageUrl } from "@shopware-pwa/helpers";
 import { PropertyGroupOption } from "@shopware-pwa/commons";
-
 
 /**
  * interface for {@link useCartItem} composable
@@ -30,7 +29,7 @@ export interface IUseCartItem {
   itemSpecialPrice: ComputedRef<number | undefined>;
   itemImageThumbnailUrl: ComputedRef<string>;
   itemOptions: ComputedRef<PropertyGroupOption[]>;
-  itemType: ComputedRef<LineItemType | undefined>
+  itemType: ComputedRef<LineItemType | undefined>;
   isProduct: ComputedRef<boolean>;
   isPromotion: ComputedRef<boolean>;
   itemStock: ComputedRef<number | undefined>;
@@ -41,18 +40,18 @@ export interface IUseCartItem {
   getProductItemSeoUrlData(): Promise<Partial<Product>>;
 }
 
-
 /**
  * Composable for cart item management. Options - {@link IUseCartItem}
  *
  * @beta
  */
 export function useCartItem({
-  cartItem
-}: {cartItem: LineItem }): IUseCartItem {
-
+  cartItem,
+}: {
+  cartItem: LineItem;
+}): IUseCartItem {
   if (!cartItem) {
-    throw new Error("[useCartItem] mandatory cartItem argument is missing.")
+    throw new Error("[useCartItem] mandatory cartItem argument is missing.");
   }
   const COMPOSABLE_NAME = "useCartitem";
   const contextName = COMPOSABLE_NAME;
@@ -63,7 +62,7 @@ export function useCartItem({
     defaultsKey: COMPOSABLE_NAME,
   });
 
-  const itemQuantity = computed(() => cartItem.quantity)
+  const itemQuantity = computed(() => cartItem.quantity);
   const itemImageThumbnailUrl = computed(() =>
     getProductMainImageUrl(cartItem as any)
   );
@@ -71,27 +70,26 @@ export function useCartItem({
   // TODO: use helper instead
 
   const itemRegularPrice = computed(
-    () =>
-      
-        cartItem.price?.listPrice?.price ||
-      cartItem.price?.unitPrice
-  )
+    () => cartItem.price?.listPrice?.price || cartItem.price?.unitPrice
+  );
 
   const itemSpecialPrice = computed(
     () => cartItem.price?.listPrice && cartItem.price.unitPrice
-  )
+  );
 
   const itemOptions = computed(
-    () => (cartItem.type === "product" && (cartItem.payload as Product)?.options) || []
-  )
+    () =>
+      (cartItem.type === "product" && (cartItem.payload as Product)?.options) ||
+      []
+  );
 
-  const itemStock = computed(() => cartItem.deliveryInformation?.stock)
+  const itemStock = computed(() => cartItem.deliveryInformation?.stock);
 
-  const itemType = computed(() => cartItem.type)
+  const itemType = computed(() => cartItem.type);
 
-  const isProduct = computed(() => cartItem.type === "product")
+  const isProduct = computed(() => cartItem.type === "product");
 
-  const isPromotion = computed(() => cartItem.type === "promotion")
+  const isPromotion = computed(() => cartItem.type === "promotion");
 
   async function removeItem() {
     const result = await removeCartItem(cartItem.id, apiInstance);
@@ -100,7 +98,11 @@ export function useCartItem({
   }
 
   async function changeItemQuantity(quantity: number): Promise<void> {
-    const result = await changeCartItemQuantity(cartItem.id, quantity, apiInstance);
+    const result = await changeCartItemQuantity(
+      cartItem.id,
+      quantity,
+      apiInstance
+    );
     broadcastUpcomingErrors(result);
     refreshCart();
   }
@@ -111,7 +113,8 @@ export function useCartItem({
     }
 
     try {
-      const result = await getProduct(cartItem.referencedId,
+      const result = await getProduct(
+        cartItem.referencedId,
         {
           includes: (getDefaults() as any).getProductItemsSeoUrlsData.includes,
           associations: (getDefaults() as any).getProductItemsSeoUrlsData
@@ -141,6 +144,5 @@ export function useCartItem({
     itemImageThumbnailUrl,
     isProduct,
     isPromotion,
-  
   };
 }

--- a/packages/composables/src/logic/useOrderDetails.ts
+++ b/packages/composables/src/logic/useOrderDetails.ts
@@ -122,9 +122,7 @@ export function useOrderDetails(params: { order: Ref<Order> | Order }): {
     () => _sharedOrder.value?.deliveries?.[0]?.shippingOrderAddress
   );
 
-  const shippingCosts = computed(
-    () => _sharedOrder.value?.shippingTotal
-  );
+  const shippingCosts = computed(() => _sharedOrder.value?.shippingTotal);
   const subtotal = computed(() => _sharedOrder.value?.price?.positionPrice);
   const total = computed(() => _sharedOrder.value?.price?.totalPrice);
   const status = computed(() => _sharedOrder.value?.stateMachineState?.name);

--- a/packages/nuxt-module/__tests__/module.spec.ts
+++ b/packages/nuxt-module/__tests__/module.spec.ts
@@ -30,7 +30,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
   let webpackConfig: any = {};
   let webpackContext: any = {};
   let methods: Function[] = [];
-  let moduleObject: any = {
+  const moduleObject: any = {
     options: {
       rootDir: __dirname,
       router: {
@@ -63,28 +63,6 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-
-    moduleObject = {
-      options: {
-        rootDir: __dirname,
-        router: {
-          middleware: [],
-        },
-        features: {
-          store: null,
-        },
-      },
-      addLayout: jest.fn(),
-      extendRoutes: jest.fn(),
-      addPlugin: jest.fn(),
-      nuxt: {
-        hook: jest.fn(),
-        resolver: {
-          resolveModule: jest.fn(),
-        },
-      },
-      extendBuild: (method: Function): number => methods.push(method),
-    };
 
     mockedUtils.loadConfig.mockResolvedValue({
       shopwareEndpoint: "mockedEndpoint",

--- a/packages/nuxt-module/__tests__/module.spec.ts
+++ b/packages/nuxt-module/__tests__/module.spec.ts
@@ -438,4 +438,31 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
       options: expect.anything(),
     });
   });
+
+  it("should guess server mode from filename's suffix", async () => {
+    mockedFiles.getAllFiles.mockReturnValueOnce([
+      "/file/path/plugins/someServerPlugin.server.ts",
+    ]);
+    await runModule(moduleObject, {});
+    expect(moduleObject.addPlugin).toBeCalledWith({
+      fileName: "sampleServerPlugin.server.js",
+      mode: "server",
+      options: {},
+      src: '/file/path/plugins/someServerPlugin.server.ts',
+    });
+   
+  });
+  it("should guess client mode from filename's suffix", async () => {
+    mockedFiles.getAllFiles.mockReturnValueOnce([
+      "/file/path/plugins/someClientPlugin.client.ts",
+    ]);
+    await runModule(moduleObject, {});
+    expect(moduleObject.addPlugin).toBeCalledWith({
+      fileName: "sampleClientPlugin.client.js",
+      mode: "client",
+      options: {},
+      src: '/file/path/plugins/someClientPlugin.client.ts',
+    });
+   
+  });
 });

--- a/packages/nuxt-module/src/extendNuxtConfig.ts
+++ b/packages/nuxt-module/src/extendNuxtConfig.ts
@@ -35,7 +35,7 @@ const defaultConfig: NuxtConfig = {
       { charset: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
       { hid: "description", name: "description", content: "" },
-      { name: "generator", content: "Vue Storefront 2"},
+      { name: "generator", content: "Vue Storefront 2" },
     ],
     link: [
       { rel: "icon", type: "image/x-icon", href: "/favicon.ico" },
@@ -103,9 +103,9 @@ const defaultConfig: NuxtConfig = {
   },
   generate: {
     exclude: [
-      /^\/search/ // do not generate static page for search page
-    ]
-  }
+      /^\/search/, // do not generate static page for search page
+    ],
+  },
 };
 
 const configs: NuxtConfig[] = [defaultConfig];

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -130,14 +130,18 @@ export async function runModule(
   const pluginFiles = getAllFiles(
     path.join(moduleObject.options.srcDir, "plugins")
   ).filter((filePath) => /.+.(js|ts)$/.test(filePath)); // get only js and ts files
+  const pluginModes = ['client', 'server']
+  const modePattern = new RegExp(`.(${pluginModes.join('|')}).(js|ts)$`)
   pluginFiles.forEach((pluginPath) => {
     const pluginFilename = pluginPath.replace(/^.*[\\\/]/, "");
+    const pluginMode = pluginFilename.match(modePattern)?.filter(mode => pluginModes.includes(mode) ? mode : undefined)?.[0];
     moduleObject.addPlugin({
       src: pluginPath,
       fileName: pluginFilename,
+      mode: pluginMode,
       options: moduleOptions,
     });
-    console.info(`"${pluginFilename}" plugin was registered automatically.`);
+    console.info(`"${pluginFilename}" plugin was registered automatically in ${pluginMode ?? 'client&server'} mode.`);
   });
 
   let config = merge({}, getDefaultApiParams());

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -130,18 +130,27 @@ export async function runModule(
   const pluginFiles = getAllFiles(
     path.join(moduleObject.options.srcDir, "plugins")
   ).filter((filePath) => /.+.(js|ts)$/.test(filePath)); // get only js and ts files
-  const pluginModes = ['client', 'server']
-  const modePattern = new RegExp(`.(${pluginModes.join('|')}).(js|ts)$`)
+
+  const pluginModes = ["client", "server"];
+  const modePattern = new RegExp(`.(${pluginModes.join("|")}).(js|ts)$`);
   pluginFiles.forEach((pluginPath) => {
     const pluginFilename = pluginPath.replace(/^.*[\\\/]/, "");
-    const pluginMode = pluginFilename.match(modePattern)?.filter(mode => pluginModes.includes(mode) ? mode : undefined)?.[0];
+    const pluginMode = pluginFilename
+      .match(modePattern)
+      ?.filter((mode) => (pluginModes.includes(mode) ? mode : undefined))?.[0];
+
     moduleObject.addPlugin({
       src: pluginPath,
       fileName: pluginFilename,
-      mode: pluginMode,
+      mode: pluginMode || undefined,
       options: moduleOptions,
     });
-    console.info(`"${pluginFilename}" plugin was registered automatically in ${pluginMode ?? 'client&server'} mode.`);
+
+    console.info(
+      `"${pluginFilename}" plugin was registered automatically in ${
+        pluginMode ?? "client&server"
+      } mode.`
+    );
   });
 
   let config = merge({}, getDefaultApiParams());


### PR DESCRIPTION
## Changes

partially closes: #1864
- guess nuxt plugin's mode (client or server) from filename's suffix using pattern: `%plugin_name%.(client|server).(js|ts)`

<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
