### PR TITLE
fix(default-theme): remove duplicated import

### DIFF
--- a/packages/default-theme/src/components/SwProductDetails.vue
+++ b/packages/default-theme/src/components/SwProductDetails.vue
@@ -68,13 +68,17 @@
 </template>
 <script>
 import { SfAlert, SfAddToCart, SfLoader } from "@storefront-ui/vue"
-import { getProductNumber, getProductOptions } from "@shopware-pwa/helpers"
+import {
+  getProductNumber,
+  getProductOptions,
+  getProductUrl,
+  getTranslatedProperty
+} from "@shopware-pwa/helpers"
 import {
   useAddToCart,
   useProductConfigurator,
   useNotifications,
 } from "@shopware-pwa/composables"
-import { getProductUrl, getTranslatedProperty } from "@shopware-pwa/helpers"
 import { computed, watch, toRefs } from "@vue/composition-api"
 import SwButton from "@/components/atoms/SwButton.vue"
 import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
@@ -85,7 +89,6 @@ export default {
     SfAlert,
     SfAddToCart,
     SfLoader,
-    SwButton: () => import("@/components/atoms/SwButton.vue"),
     SwProductHeading: () => import("@/components/SwProductHeading.vue"),
     SwProductSelect: () => import("@/components/SwProductSelect.vue"),
     SwPluginSlot,


### PR DESCRIPTION
## Changes

Removes a duplicated import of the SwButton component in the SwProductDetails component. Since this just removes an unused import, no functionality is affected.

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
