### PR TITLE
fix(default-theme): override hardcoded close button in bottom menu

### DIFF
--- a/packages/default-theme/src/components/SwBottomMenu.vue
+++ b/packages/default-theme/src/components/SwBottomMenu.vue
@@ -47,11 +47,20 @@
         </SfListItem>
       </SfList>
     </transition>
+
+    <template v-slot:close-mobile>
+      <SfButton
+        class="sf-button--full-width sf-bottom-modal__cancel"
+        aria-label="Close"
+        @click="$emit('close')"
+        v-text="$t('Close')"
+      />
+    </template>
   </SfBottomModal>
 </template>
 
 <script>
-import { SfBottomModal, SfIcon, SfList } from "@storefront-ui/vue"
+import { SfBottomModal, SfButton, SfIcon, SfList } from "@storefront-ui/vue"
 import { useNavigation, useUIState } from "@shopware-pwa/composables"
 import { onMounted } from "@vue/composition-api"
 import { getCategoryUrl, getTranslatedProperty } from "@shopware-pwa/helpers"
@@ -60,6 +69,7 @@ export default {
   name: "SwBottomMenu",
   components: {
     SfBottomModal,
+    SfButton,
     SfIcon,
     SfList,
   },


### PR DESCRIPTION
## Changes

The default close button for the `SwBottomMenu` has the text "Cancel" hardcoded as value. This change overrides the `close-mobile` slot of the `SfBottomModal` with a button that has the translatable text `Close`.

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
