### PR TITLE
feat(default-theme): Improve SwImage component with srcset

### DIFF
--- a/packages/default-theme/src/cms/elements/CmsElementImage.vue
+++ b/packages/default-theme/src/cms/elements/CmsElementImage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="imgUrl">
+  <div v-if="imagesUrl && imagesUrl.length">
     <SwLink
       v-if="link"
       :link="link"
@@ -7,7 +7,7 @@
       class="cms-element-image__link"
     >
       <SwImage
-        :src="imgUrl"
+        :srcset="imagesUrl"
         :title="title"
         :alt="alt"
         :loading="lazyLoad"
@@ -16,7 +16,7 @@
     </SwLink>
     <SwImage
       v-else
-      :src="imgUrl"
+      :srcset="imagesUrl"
       :title="title"
       :alt="alt"
       :loading="lazyLoad"
@@ -57,8 +57,8 @@ export default {
       return this.content && this.content.data && this.content.data.media
     },
 
-    imgUrl() {
-      return getResizedImage(this.getMedia && this.getMedia.url)
+    imagesUrl() {
+      return this.getMedia?.thumbnails ?? []
     },
 
     lazyLoad() {

--- a/packages/default-theme/src/components/atoms/SwImage.vue
+++ b/packages/default-theme/src/components/atoms/SwImage.vue
@@ -1,21 +1,41 @@
 <template>
-  <SfImage v-bind="{ ...$props, ...$attrs }" :placeholder="placeholder" />
+  <SfImage :src="imgUrl" :srcsets="srcsets" v-bind="{ ...$props, ...$attrs }" :placeholder="placeholder" />
 </template>
 
 <script>
 import { SfImage } from "@storefront-ui/vue"
 import getPlaceholderImage from "@/helpers/images/getPlaceholderImage.js"
+import { computed } from "@vue/composition-api"
 
 export default {
   name: "SwImage",
   components: {
     SfImage,
   },
+  props: {
+    srcset: Array,
+    src: {
+      type: String,
+      default: ''
+    }
+  },
   setup(props, { root }) {
     const width = (props.imageWidth && props.imageWidth + "px") || "100%"
     const height = (props.imageHeight && props.imageHeight + "px") || "100%"
+    const srcsets = computed(() => props.srcset?.map(item => ({
+      src: item.url,
+      width: item.width,
+      resolution: item.width
+      })) ?? []
+    )
+    const imgUrl = computed(() => props.srcset?.reduce(function (res, thumb) {
+      return thumb.width < res.width ? thumb : res;
+    })?.url ?? props.src)
+
     return {
       placeholder: getPlaceholderImage(width, height),
+      srcsets,
+      imgUrl
     }
   },
 }


### PR DESCRIPTION
this PR closes https://github.com/vuestorefront/shopware-pwa/issues/1884
## Changes
- add new prop `srcset` for SwImage component.
- update srcset data of SwImage inside CmsElementImage component.

<!-- Paste here screenshot if there are visual changes -->

### Checklist
- [x] implement computed property for src set
- [x] find all occurances of SwImage component used in default-theme
- [x] pass src set extracted from available data from the parent (ignore if it's not possible).
- [x] use breakpoints set as default coming with media object (400, 800, 1200?).

