### PR TITLE
feat(default-theme): Category image in MegaMenu

### DIFF
--- a/packages/composables/src/internalHelpers/defaultApiParams.json
+++ b/packages/composables/src/internalHelpers/defaultApiParams.json
@@ -229,6 +229,7 @@
   },
   "useNavigation": {
     "associations": {
+      "media": {},
       "seoUrls": {}
     },
     "includes": {
@@ -239,7 +240,8 @@
         "id",
         "children",
         "translated",
-        "type"
+        "type",
+        "media"
       ],
       "seo_url": ["pathInfo", "seoPathInfo"]
     }

--- a/packages/default-theme/src/components/SwMegaMenu.vue
+++ b/packages/default-theme/src/components/SwMegaMenu.vue
@@ -37,16 +37,30 @@
         </SfList>
       </div>
     </div>
+    <div v-if="category.media" class="sw-mega-menu__image-container">
+      <nuxt-link
+        :to="$routing.getUrl(getCategoryUrl(category))"
+      >
+        <SwImage
+          :src="getImageUrl(category.media)"
+          :alt="category.media.alt || ''"
+          :width="310"
+          :height="250"
+        />
+      </nuxt-link>
+    </div>
   </SfMegaMenu>
 </template>
 
 <script>
 import { SfMegaMenu, SfMenuItem, SfList, SfHeading } from "@storefront-ui/vue"
+import getResizedImage from "@/helpers/images/getResizedImage.js"
 import { getCategoryUrl, getTranslatedProperty } from "@shopware-pwa/helpers"
+import SwImage from "@/components/atoms/SwImage.vue"
 
 export default {
   name: "SwMegaMenu",
-  components: { SfMegaMenu, SfMenuItem, SfList, SfHeading },
+  components: { SfMegaMenu, SfMenuItem, SfList, SfHeading, SwImage },
   props: {
     category: {
       type: Object,
@@ -58,7 +72,11 @@ export default {
     },
   },
   setup(props, { root }) {
-    return { getCategoryUrl, getTranslatedProperty }
+    function getImageUrl(media) {
+      return getResizedImage(media?.url, { width: 310, height: 250 })
+    }
+
+    return { getImageUrl, getCategoryUrl, getTranslatedProperty }
   },
 }
 </script>


### PR DESCRIPTION
## Changes
this PR closes #714
- default-theme: show category image visible in the top navigation menu.
- composables: add media field for `useNavigation` in defaultApiParams.json.
![Screen Shot 2022-06-07 at 11 23 45 AM](https://user-images.githubusercontent.com/29194019/172295638-90cf6ea5-b67f-4dd8-81f3-c56e15ca6562.png)

### Checklist

- [x] defaultApiParams are extended with "media" entity, in associations and includes (see https://github.com/vuestorefront/shopware-pwa/blob/master/packages/composables/src/internalHelpers/defaultApiParams.json#L230)
- [x] displaying logic is followed by standard storefront design -> https://pwa-demo-api.shopware.com/trunk/ and hover on "Women" category then you can see the category image on right top area.
- [x]  using category image in mega menu, taken from category endpoint
- [x] check the difference in performance before and after attaching a media
Before:
![Screen Shot 2022-06-07 at 10 40 15 AM](https://user-images.githubusercontent.com/29194019/172295105-7c0f3150-5f3d-4a52-b87e-a2ed24dfed11.png)
After
![Screen Shot 2022-06-07 at 10 37 33 AM](https://user-images.githubusercontent.com/29194019/172295102-ab62a350-9558-49fa-8963-abd0802b5bf8.png)


