### PR TITLE
feat(default-theme): Add service menu

### DIFF
--- a/packages/default-theme/src/components/organisms/SwFooterNavigation.vue
+++ b/packages/default-theme/src/components/organisms/SwFooterNavigation.vue
@@ -5,44 +5,16 @@
     :multiple="true"
     :open="open"
   >
-    <SfFooterColumn
-      v-for="category in navigationElements"
-      :key="category.id"
-      :title="getTranslatedProperty(category, 'name')"
-    >
-      <SfList v-if="category.children">
-        <SfListItem
-          v-for="childCategory in category.children"
-          :key="childCategory.id"
-        >
-          <a
-            v-if="isLinkCategory(childCategory)"
-            class="sf-header__link"
-            :href="getCategoryUrl(childCategory)"
-            target="_blank"
-          >
-            <SfMenuItem :label="getTranslatedProperty(childCategory, 'name')" />
-          </a>
-          <nuxt-link
-            v-else
-            class="sf-header__link"
-            :to="$routing.getUrl(getCategoryUrl(childCategory))"
-          >
-            <SfMenuItem :label="getTranslatedProperty(childCategory, 'name')" />
-          </nuxt-link>
-        </SfListItem>
-      </SfList>
-    </SfFooterColumn>
+    <SwFooterNavigationColumn v-for="category in navigationElements" :key="category.id" :category="category" />
+    <SwFooterService />
   </SfFooter>
 </template>
 <script>
-import { SfFooter, SfList, SfMenuItem } from "@storefront-ui/vue"
+import { SfFooter } from "@storefront-ui/vue"
+import SwFooterNavigationColumn from "@/components/organisms/SwFooterNavigationColumn.vue"
+import SwFooterService from "@/components/organisms/SwFooterService.vue"
 import { ref, watch, computed } from "@vue/composition-api"
-import {
-  getCategoryUrl,
-  isLinkCategory,
-  getTranslatedProperty,
-} from "@shopware-pwa/helpers"
+import { getTranslatedProperty } from "@shopware-pwa/helpers"
 import { useNavigation, useSharedState } from "@shopware-pwa/composables"
 import { useDomains } from "@/logic"
 
@@ -59,8 +31,8 @@ export default {
   name: "SwFooterNavigation",
   components: {
     SfFooter,
-    SfList,
-    SfMenuItem,
+    SwFooterNavigationColumn,
+    SwFooterService,
   },
   setup() {
     const { loadNavigationElements, navigationElements } = useNavigation({
@@ -91,8 +63,6 @@ export default {
 
     return {
       navigationElements,
-      getCategoryUrl,
-      isLinkCategory,
       column,
       open,
       getTranslatedProperty,

--- a/packages/default-theme/src/components/organisms/SwFooterNavigationColumn.vue
+++ b/packages/default-theme/src/components/organisms/SwFooterNavigationColumn.vue
@@ -1,0 +1,59 @@
+<template>
+  <SfFooterColumn
+    v-if="category"
+    :key="category.id"
+    :title="getTranslatedProperty(category, 'name')"
+  >
+    <SfList v-if="category.children">
+      <SfListItem
+        v-for="childCategory in category.children"
+        :key="childCategory.id"
+      >
+        <a
+          v-if="isLinkCategory(childCategory)"
+          class="sf-header__link"
+          :href="getCategoryUrl(childCategory)"
+          target="_blank"
+        >
+          <SfMenuItem :label="getTranslatedProperty(childCategory, 'name')" />
+        </a>
+        <nuxt-link
+          v-else
+          class="sf-header__link"
+          :to="$routing.getUrl(getCategoryUrl(childCategory))"
+        >
+          <SfMenuItem :label="getTranslatedProperty(childCategory, 'name')" />
+        </nuxt-link>
+      </SfListItem>
+    </SfList>
+  </SfFooterColumn>
+</template>
+<script>
+import { SfList, SfMenuItem } from "@storefront-ui/vue"
+import {
+  getCategoryUrl,
+  isLinkCategory,
+  getTranslatedProperty,
+} from "@shopware-pwa/helpers"
+
+export default {
+  name: "SwFooterNavigationColumn",
+  components: {
+    SfList,
+    SfMenuItem,
+  },
+  props: {
+    category: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  setup() {
+    return {
+      getCategoryUrl,
+      isLinkCategory,
+      getTranslatedProperty,
+    }
+  },
+}
+</script>

--- a/packages/default-theme/src/components/organisms/SwFooterService.vue
+++ b/packages/default-theme/src/components/organisms/SwFooterService.vue
@@ -1,0 +1,33 @@
+<template>
+  <SwFooterNavigationColumn     
+    v-if="navigationElements && navigationElements.length"
+    :key="navigationElements[0].id" 
+    :category="navigationElements[0]" 
+  />
+</template>
+<script>
+import { getTranslatedProperty } from "@shopware-pwa/helpers"
+import { ref } from "@vue/composition-api"
+import { useNavigation, useSharedState } from "@shopware-pwa/composables"
+import SwFooterNavigationColumn from "@/components/organisms/SwFooterNavigationColumn.vue"
+
+export default {
+  name: "SwFooterService",
+  components: {
+    SwFooterNavigationColumn,
+  },
+  setup() {
+    const { loadNavigationElements, navigationElements } = useNavigation({
+      type: "service-navigation",
+    })
+    const { preloadRef } = useSharedState()
+    preloadRef(navigationElements, async () => {
+      await loadNavigationElements({ depth: 2 })
+    })
+    return {
+      navigationElements,
+      getTranslatedProperty,
+    }
+  },
+}
+</script>

--- a/packages/default-theme/src/components/organisms/SwFooterService.vue
+++ b/packages/default-theme/src/components/organisms/SwFooterService.vue
@@ -1,13 +1,12 @@
 <template>
   <SwFooterNavigationColumn     
-    v-if="navigationElements && navigationElements.length"
-    :key="navigationElements[0].id" 
-    :category="navigationElements[0]" 
+    v-if="category"
+    :key="category.id" 
+    :category="category" 
   />
 </template>
 <script>
-import { getTranslatedProperty } from "@shopware-pwa/helpers"
-import { ref } from "@vue/composition-api"
+import { computed } from "@vue/composition-api"
 import { useNavigation, useSharedState } from "@shopware-pwa/composables"
 import SwFooterNavigationColumn from "@/components/organisms/SwFooterNavigationColumn.vue"
 
@@ -24,9 +23,10 @@ export default {
     preloadRef(navigationElements, async () => {
       await loadNavigationElements({ depth: 2 })
     })
+    const category = computed(() => navigationElements.value?.[0])
+
     return {
-      navigationElements,
-      getTranslatedProperty,
+      category,
     }
   },
 }


### PR DESCRIPTION
## Changes
This PR closes https://github.com/vuestorefront/shopware-pwa/issues/1890
- Create a new component `SwFooterNavigationColumn` to contains the UI of footer column.
- Create a new component `SwFooterService` to fetch service menu from useNavigation.
- Update `SwFooterNavigation` component.

![Screen Shot 2022-06-08 at 5 09 55 PM](https://user-images.githubusercontent.com/29194019/172591426-4776144c-4085-4748-b760-43dbdc5a8894.png)

### Checklist

- [x] store-api documentation is read to have a basic knowledge how it works: https://shopware.stoplight.io/docs/store-api/b3A6ODI2NTY3MQ-fetch-a-navigation-menu
- [x] `useNavigation` composable is used to fetch `service-menu` predefined type of navigation
- [x] additional component is created to represent the information fetched from API regarding service menu
- [x] design: can follow the standard storefront display
