### PR TITLE
fix(default-theme): Adding top navigation container for using out of header

### DIFF
--- a/packages/default-theme/src/components/SwTopNavigationContainer.vue
+++ b/packages/default-theme/src/components/SwTopNavigationContainer.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="nav-container">
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  
+}
+</script>
+
+<style lang="scss" scoped>
+  .nav-container {
+    z-index: 1;
+    position: relative;
+  }
+</style>

--- a/packages/default-theme/src/components/forms/SwAddressManager.vue
+++ b/packages/default-theme/src/components/forms/SwAddressManager.vue
@@ -39,7 +39,7 @@
         class="title desktop-only"
         :level="4"
       />
-      <div v-if="isEditModeOpen" class="address-manager__list">
+      <div v-if="!isEditModeOpen" class="address-manager__list">
         <div
           v-for="address in addresses"
           :key="address.id"
@@ -72,6 +72,7 @@
         v-else
         @success="onAddressSave"
         @cancel="isModalOpen = false"
+        :address=activeAddress
       />
     </SfModal>
   </div>


### PR DESCRIPTION
## Changes

Closes #1537 

### Checklist

- [x] Able to put SwTopNavigation out of header without error display by using SwTopNavigationContainer component
