### PR TITLE
fix(default-theme): Use translated name of order.stateMachineState

### DIFF
--- a/packages/default-theme/src/components/account/orders/Order.vue
+++ b/packages/default-theme/src/components/account/orders/Order.vue
@@ -25,7 +25,7 @@
             'text-success': order.stateMachineState.technicalName === 'closed',
             'text-info': order.stateMachineState.technicalName === 'open',
           }"
-          >{{ order.stateMachineState.name }}</span
+          >{{ order.stateMachineState.translated.name }}</span
         >
       </template>
     </SfTableData>


### PR DESCRIPTION
## Changes

In the default theme when the order history in a customer's account is viewed in a different language the order status of each order remains empty, since `.name` is used instead of `.translated.name`.
This PR fixes the component.

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
