### PR TITLE
fix(nuxt-module): clean up the dump bundle file after the build

### DIFF
--- a/api/helpers.api.md
+++ b/api/helpers.api.md
@@ -29,10 +29,19 @@ export function getCmsEntityByType(page?: CmsPageResponse | null): Product | Cat
 export function getCmsLayoutConfiguration(content: CmsBlock | CmsSection): LayoutConfiguration;
 
 // @public
-export function getCmsLink(content?: CmsSlot): String;
+export function getCmsLink(content?: Omit<CmsSlot, "data"> & {
+    data?: {
+        url?: string;
+    };
+}): String;
 
 // @public
-export function getCmsLinkTarget(content?: CmsSlot): String;
+export function getCmsLinkTarget(content?: Omit<CmsSlot, "data"> & {
+    data?: {
+        url?: string;
+        newTab?: boolean;
+    };
+}): String;
 
 // @public (undocumented)
 export function getCmsTechnicalPath(page: CmsPageResponse): string | undefined;

--- a/docs/landing/resources/api/helpers.getcmslink.md
+++ b/docs/landing/resources/api/helpers.getcmslink.md
@@ -9,14 +9,18 @@ Gets the link of a cms slot
 <b>Signature:</b>
 
 ```typescript
-export declare function getCmsLink(content?: CmsSlot): String;
+export declare function getCmsLink(content?: Omit<CmsSlot, "data"> & {
+    data?: {
+        url?: string;
+    };
+}): String;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  content | CmsSlot |  |
+|  content | Omit&lt;CmsSlot, "data"&gt; &amp; { data?: { url?: string; }; } |  |
 
 <b>Returns:</b>
 

--- a/docs/landing/resources/api/helpers.getcmslinktarget.md
+++ b/docs/landing/resources/api/helpers.getcmslinktarget.md
@@ -9,14 +9,19 @@ Return the target attribute for the cms link
 <b>Signature:</b>
 
 ```typescript
-export declare function getCmsLinkTarget(content?: CmsSlot): String;
+export declare function getCmsLinkTarget(content?: Omit<CmsSlot, "data"> & {
+    data?: {
+        url?: string;
+        newTab?: boolean;
+    };
+}): String;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  content | CmsSlot |  |
+|  content | Omit&lt;CmsSlot, "data"&gt; &amp; { data?: { url?: string; newTab?: boolean; }; } |  |
 
 <b>Returns:</b>
 

--- a/packages/helpers/src/cms/getCmsLink.ts
+++ b/packages/helpers/src/cms/getCmsLink.ts
@@ -5,6 +5,8 @@ import { CmsSlot } from "@shopware-pwa/commons";
  *
  * @public
  */
-export function getCmsLink(content?: CmsSlot): String {
+export function getCmsLink(
+  content?: Omit<CmsSlot, "data"> & { data?: { url?: string } }
+): String {
   return content?.data?.url || "";
 }

--- a/packages/helpers/src/cms/getCmsLinkTarget.ts
+++ b/packages/helpers/src/cms/getCmsLinkTarget.ts
@@ -5,7 +5,11 @@ import { CmsSlot } from "@shopware-pwa/commons";
  *
  * @public
  */
-export function getCmsLinkTarget(content?: CmsSlot): String {
+export function getCmsLinkTarget(
+  content?: Omit<CmsSlot, "data"> & {
+    data?: { url?: string; newTab?: boolean };
+  }
+): String {
   const inNewTab = content?.data?.newTab;
 
   return inNewTab ? "_blank" : "_self";

--- a/packages/nuxt-module/__tests__/module.spec.ts
+++ b/packages/nuxt-module/__tests__/module.spec.ts
@@ -468,7 +468,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     expect(mockedFse.removeSync).toBeCalledWith(pathToDelete);
   });
 
-  it("should remove a temporary json file after the build is done", async () => {
+  it("should catch the error while a temporary json cannot be deleted", async () => {
     moduleObject.options.dev = false;
     const afterBuildMethods: any[] = [];
     mockedFse.existsSync.mockReturnValue(true);

--- a/packages/nuxt-module/__tests__/module.spec.ts
+++ b/packages/nuxt-module/__tests__/module.spec.ts
@@ -442,6 +442,58 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     );
   });
 
+  it("should remove a temporary json file after the build is done", async () => {
+    moduleObject.options.dev = false;
+    const afterBuildMethods: any[] = [];
+    mockedFse.existsSync.mockReturnValue(true);
+    moduleObject.nuxt.hook.mockImplementation(
+      (hookName: string, method: Function) => {
+        hookName === "build:done" && afterBuildMethods.push(method);
+      }
+    );
+    await runModule(moduleObject, {});
+    expect(moduleObject.nuxt.hook).toBeCalledWith(
+      "build:done",
+      expect.any(Function)
+    );
+
+    expect(afterBuildMethods.length).toEqual(1);
+    await afterBuildMethods[0](moduleObject);
+    const pathToDelete = path.join(
+      moduleObject.options.rootDir,
+      ".shopware-pwa",
+      "pwa-bundles.json"
+    );
+    expect(mockedFse.existsSync).toBeCalledWith(pathToDelete);
+    expect(mockedFse.removeSync).toBeCalledWith(pathToDelete);
+  });
+
+  it("should remove a temporary json file after the build is done", async () => {
+    moduleObject.options.dev = false;
+    const afterBuildMethods: any[] = [];
+    mockedFse.existsSync.mockReturnValue(true);
+    mockedFse.removeSync.mockImplementationOnce(() => {
+      throw new Error("test");
+    });
+
+    moduleObject.nuxt.hook.mockImplementation(
+      (hookName: string, method: Function) => {
+        hookName === "build:done" && afterBuildMethods.push(method);
+      }
+    );
+    await runModule(moduleObject, {});
+    expect(moduleObject.nuxt.hook).toBeCalledWith(
+      "build:done",
+      expect.any(Function)
+    );
+
+    await afterBuildMethods[0](moduleObject);
+    expect(consoleErrorSpy).toHaveBeenLastCalledWith(
+      "error while trying to remove a dump file: ",
+      expect.any(Error)
+    );
+  });
+
   it("should add plugins registered in theme - js|ts files only including extracted mode", async () => {
     mockedFiles.getAllFiles.mockReturnValueOnce([
       "/file/path/plugins/notifications.js",

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -299,6 +299,20 @@ export async function runModule(
       const sourceDir = path.join(TARGET_SOURCE, "static");
       const destinationDir = path.join(builder.options.rootDir, "static");
       await fse.copy(sourceDir, destinationDir);
+
+      const temporaryShopwarePwaDumpFile = path.join(
+        moduleObject.options.rootDir,
+        ".shopware-pwa",
+        "pwa-bundles.json"
+      );
+
+      if (fse.existsSync(temporaryShopwarePwaDumpFile)) {
+        try {
+          fse.removeSync(temporaryShopwarePwaDumpFile);
+        } catch (error) {
+          console.error("error while trying to remove a dump file: ", error);
+        }
+      }
       console.info(
         "Moved static files to root directory static folder. Make sure your static files are placed inside `src/static` directory."
       );


### PR DESCRIPTION
## Changes

cli: changes a way how the plugin config json is being fetched, use sync api call instead downloading a static file from the server
nuxt module: Removes a configuration file for the plugins once the build is done.

<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
