### PR TITLE
fix(api-client): parsing error message when API cannot be reached

### DIFF
--- a/packages/shopware-6-client/__tests__/apiInterceptors.spec.ts
+++ b/packages/shopware-6-client/__tests__/apiInterceptors.spec.ts
@@ -264,5 +264,16 @@ describe("apiInterceptors", () => {
         });
       }
     });
+
+    it("it should not fail when api is unreachable", async () => {
+      try {
+        await errorInterceptor({} as any);
+      } catch (error) {
+        expect(error).toStrictEqual({
+          statusCode: 500,
+          messages: [],
+        });
+      }
+    });
   });
 });

--- a/packages/shopware-6-client/src/interceptors/errorInterceptor.ts
+++ b/packages/shopware-6-client/src/interceptors/errorInterceptor.ts
@@ -55,7 +55,7 @@ const guessTheStatusCodeFromTheMessage = (message: string): number => {
  * @returns {(string|ShopwareError[])} single message if statusCode !== 400, array of native errors otherwise
  */
 const extractApiErrorMessage = (error: ShopwareApiError): ShopwareError[] => {
-  return error.response.data?.errors || [];
+  return error.response?.data?.errors || [];
 };
 
 /**


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

Fixes problem of parsing response API messages when API is not reachable

<!-- Paste here screenshot if there are visual changes -->
