### PR TITLE
fix(default-theme): breadcrumb routing issue

### DIFF
--- a/packages/default-theme/src/layouts/default.vue
+++ b/packages/default-theme/src/layouts/default.vue
@@ -11,7 +11,6 @@
         v-show="getBreadcrumbs.length > 0"
         :breadcrumbs="getBreadcrumbs"
         class="sw-breadcrumbs layout__sized"
-        @click="redirectTo"
       />
     </SwPluginSlot>
 
@@ -113,11 +112,6 @@ export default defineComponent({
     }
   },
   middleware: ["pages"],
-  methods: {
-    redirectTo(route) {
-      return this.$router.push(this.$routing.getUrl(route.link))
-    },
-  },
 })
 </script>
 


### PR DESCRIPTION
## Changes

Fixes an issue where the breadcrumb navigation is not usable from product page. There's no need for a redirect method since it uses the nuxt-link in sfLink-Component

Closes https://github.com/vuestorefront/shopware-pwa/issues/1933

### Checklist

- [] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
