### PR TITLE
feat(default-theme): Set HTTP status code when accessing error page through SSR

### DIFF
--- a/packages/default-theme/src/components/views/error.page.vue
+++ b/packages/default-theme/src/components/views/error.page.vue
@@ -61,8 +61,10 @@ export default {
       default: () => {},
     },
   },
-  data() {
-    return {}
+  fetch() {
+    if (process.server) {
+      this.$nuxt.context.res.statusCode = this.code
+    }
   },
   computed: {
     code() {


### PR DESCRIPTION
Set the HTTP status code to the correct error code when accessing an error page through SSR. 

This change helps crawlers and scripts to detect the correct status of a page.

## Changes

closes #1938

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
