### PR TITLE
chore(default-theme): Remove unused code & styling from detail page

### DIFF
--- a/packages/default-theme/src/components/views/frontend.detail.page.vue
+++ b/packages/default-theme/src/components/views/frontend.detail.page.vue
@@ -26,12 +26,12 @@
   </div>
 </template>
 <script>
+import { computed } from "@vue/composition-api"
+
 import CmsPage from "sw-cms/CmsPage"
-import { useUser, useUIState, useDefaults } from "@shopware-pwa/composables"
 import SwGoBackArrow from "@/components/atoms/SwGoBackArrow.vue"
 import SwProductAdvertisement from "@/components/SwProductAdvertisement.vue"
 import SwPluginSlot from "sw-plugins/SwPluginSlot.vue"
-import { computed, provide } from "@vue/composition-api"
 const SwProductGallery = () => import("@/components/SwProductGallery.vue")
 const SwProductDetails = () => import("@/components/SwProductDetails.vue")
 const SwProductCrossSells = () =>
@@ -58,19 +58,10 @@ export default {
     },
   },
   setup(props) {
-    const { isLoggedIn } = useUser()
-    const { switchState: switchLoginModalState } = useUIState({
-      stateName: "LOGIN_MODAL_STATE",
-    })
     const product = computed(() => props.page.product)
     const cmsPage = computed(() => props.page.cmsPage)
-    const { getIncludesConfig } = useDefaults({
-      defaultsKey: "useProductListing",
-    })
 
     return {
-      isLoggedIn,
-      switchLoginModalState,
       product,
       cmsPage,
     }
@@ -95,55 +86,8 @@ export default {
   }
 }
 
-.section {
-  padding: 0 var(--spacer-base);
-  @include for-desktop {
-    padding: 0;
-  }
-}
-
-.images-grid {
-  ::v-deep .sf-image {
-    max-width: 100%;
-  }
-  &__row {
-    display: flex;
-    & + & {
-      margin-top: calc(var(--spacer-base) / 2);
-      @include for-desktop {
-        margin-top: var(--spacer-base);
-      }
-    }
-  }
-  &__col {
-    margin: 0;
-    & + & {
-      margin-left: calc(var(--spacer-base) / 2);
-      @include for-desktop {
-        margin-left: var(--spacer-base);
-      }
-    }
-  }
-}
-
-.product {
-  @include for-desktop {
-    display: flex;
-  }
-  &__gallery,
-  &__description {
-    flex: 1;
-  }
-  &__description {
-    padding: 0 var(--spacer-sm);
-    @include for-desktop {
-      margin-left: calc(var(--spacer-base) * 3);
-    }
-  }
-
-  &__advertisement {
-    margin-top: var(--spacer-2xl, 3rem);
-  }
+.product__advertisement {
+  margin-top: var(--spacer-2xl, 3rem);
 }
 
 .product-page-back {


### PR DESCRIPTION
## Changes

The frontend detail page has a bunch of code that doesn't do anything and some scoped styles that don't affect any elements (seems like they are leftovers from some old changes). This PR removes those.

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
