### PR TITLE
fix: typo in interface

### DIFF
--- a/packages/commons/interfaces/models/system/salutation/Salutation.ts
+++ b/packages/commons/interfaces/models/system/salutation/Salutation.ts
@@ -12,5 +12,5 @@ export interface Salutation {
   translations: SalutationTranslation[] | null;
   translated: object;
   updatedAt: string | null;
-  extenstions: object;
+  extensions: object;
 }


### PR DESCRIPTION
Shopware returns extensions not extenstions, seems to be a typo in the interface

## Changes

I did not open an issue for this, just saw that my vscode complained about my testdata taken from a real system, which did not match the provided interaface
