### PR TITLE
fix(default-theme): SwAddressForm.vue country validation bug

### DIFF
--- a/packages/default-theme/src/components/forms/SwAddressForm.vue
+++ b/packages/default-theme/src/components/forms/SwAddressForm.vue
@@ -96,10 +96,10 @@
           v-model="addressModel.countryId"
           :label="$t('Country')"
           :error-message="$t('Country must be selected')"
-          :valid="!$v.address.country.$error"
+          :valid="!$v.address.countryId.$error"
           required
           class="sf-select--underlined sw-form__input sf-component-select--underlined sw-select"
-          @blur="$v.address.country.$touch()"
+          @blur="$v.address.countryId.$touch()"
         >
           <SfComponentSelectOption
             v-for="countryOption in getCountries"
@@ -269,7 +269,7 @@ export default {
       zipcode: {
         required,
       },
-      country: {
+      countryId: {
         required,
       },
       phoneNumber: {


### PR DESCRIPTION
Set the correct property to validate in the form

## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] the [list of features](https://github.com/vuestorefront/shopware-pwa/blob/master/docs/landing/resources/features.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/vuestorefront/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
