### PR TITLE
fix(composables): remove unsupported association for navigation entities

### DIFF
--- a/packages/composables/src/internalHelpers/defaultApiParams.json
+++ b/packages/composables/src/internalHelpers/defaultApiParams.json
@@ -238,8 +238,7 @@
   },
   "useNavigation": {
     "associations": {
-      "media": {},
-      "seoUrls": {}
+      "media": {}
     },
     "includes": {
       "category": [


### PR DESCRIPTION
## Changes

Removes `seoUrls` association as it's not necessary due the urls are autoloaded for `/navigation` requests
