### PR TITLE
fix(default-theme): srcset image display wrong incase url have space

### DIFF
--- a/packages/default-theme/src/components/atoms/SwImage.vue
+++ b/packages/default-theme/src/components/atoms/SwImage.vue
@@ -29,7 +29,7 @@ export default {
     const width = (props.imageWidth && props.imageWidth + "px") || "100%"
     const height = (props.imageHeight && props.imageHeight + "px") || "100%"
     const srcsets = computed(() => props.srcset?.map(item => ({
-      src: item.url,
+      src: encodeURI(item.url),
       width: item.width,
       resolution: item.width
       })) ?? []


### PR DESCRIPTION
## Changes
- Add `encodeURI` to the url of srcset.

Before:
<img width="1505" alt="Screen Shot 2023-03-30 at 11 47 11 AM" src="https://user-images.githubusercontent.com/29194019/228732739-baced2e1-b85a-49af-9221-a075d50ad88b.png">

After:
<img width="1510" alt="Screen Shot 2023-03-30 at 11 47 30 AM" src="https://user-images.githubusercontent.com/29194019/228732757-b4479bb7-fb83-4824-8971-4080ec792163.png">

### Checklist

- [x] test srcset.
