### PR TITLE
chore: Shopware v6.5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,6 @@
   },
   "engines": {
     "node": ">=14.17.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,5 @@
   },
   "engines": {
     "node": ">=14.17.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/commons/interfaces/models/checkout/customer/Customer.ts
+++ b/packages/commons/interfaces/models/checkout/customer/Customer.ts
@@ -7,6 +7,7 @@ import { BillingAddress } from "./BillingAddress";
 import { CustomerAddress } from "./CustomerAddress";
 import { Promotion } from "../promotion/Promotion";
 import { Tag } from "../../system/tag/Tag";
+import { CustomField } from "../../common/CustomField";
 
 /**
  * @beta
@@ -46,7 +47,7 @@ export interface Customer {
   autoIncrement: number;
   tags: Tag[] | null;
   promotions: Promotion[] | null;
-  customFields: unknown;
+  customFields: CustomField[];
   productReviews: ProductReview[];
   doubleOptInConfirmDate: null | string;
   doubleOptInEmailSentDate: string;

--- a/packages/commons/interfaces/models/checkout/customer/Customer.ts
+++ b/packages/commons/interfaces/models/checkout/customer/Customer.ts
@@ -7,7 +7,6 @@ import { BillingAddress } from "./BillingAddress";
 import { CustomerAddress } from "./CustomerAddress";
 import { Promotion } from "../promotion/Promotion";
 import { Tag } from "../../system/tag/Tag";
-import { CustomField } from "../../common/CustomField";
 
 /**
  * @beta
@@ -42,14 +41,12 @@ export interface Customer {
   defaultPaymentMethod: PaymentMethod;
   defaultBillingAddress: BillingAddress;
   defaultShippingAddress: ShippingAddress;
-  activeBillingAddress: BillingAddress;
-  activeShippingAddress: ShippingAddress;
   addresses: Array<CustomerAddress>;
   orderCustomers: Array<OrderCustomer> | null;
   autoIncrement: number;
   tags: Tag[] | null;
   promotions: Promotion[] | null;
-  customFields: CustomField[];
+  customFields: unknown;
   productReviews: ProductReview[];
   doubleOptInConfirmDate: null | string;
   doubleOptInEmailSentDate: string;

--- a/packages/commons/interfaces/models/content/landing-page/LandingPage.ts
+++ b/packages/commons/interfaces/models/content/landing-page/LandingPage.ts
@@ -5,27 +5,27 @@ import { SeoUrl } from "../navigation/Navigation";
  * @public
  */
 export type LandingPage = {
-    active: boolean;
-    translations: null | unknown;
-    cmsPage: null | CmsPage;
-    cmsPageId: string;
-    name: string;
-    metaTitle: null | string;
-    metaDescription: null | string;
-    keywords: null | string;
-    url: string;
-    slotConfig: null | unknown[];
-    seoUrls: null | SeoUrl[];
-    _uniqueIdentifier: string;
-    versionId: string;
-    translated: {
-      [key: string]: string;
-    };
-    createdAt: string;
-    updatedAt: null | string;
-    extensions: unknown;
-    id: string;
-    customFields: null | unknown;
-    cmsPageVersionId: string;
-    apiAlias: "landing_page";
+  active: boolean;
+  translations: null | unknown;
+  cmsPage: null | CmsPage;
+  cmsPageId: string;
+  name: string;
+  metaTitle: null | string;
+  metaDescription: null | string;
+  keywords: null | string;
+  url: string;
+  slotConfig: null | unknown[];
+  seoUrls: null | SeoUrl[];
+  _uniqueIdentifier: string;
+  versionId: string;
+  translated: {
+    [key: string]: string;
+  };
+  createdAt: string;
+  updatedAt: null | string;
+  extensions: unknown;
+  id: string;
+  customFields: null | unknown;
+  cmsPageVersionId: string;
+  apiAlias: "landing_page";
 };

--- a/packages/commons/interfaces/response/SessionContext.ts
+++ b/packages/commons/interfaces/response/SessionContext.ts
@@ -2,8 +2,8 @@ import { PaymentMethod } from "../models/checkout/payment/PaymentMethod";
 import { ShippingMethod } from "../models/checkout/shipping/ShippingMethod";
 import { ShippingAddress } from "../models/checkout/customer/ShippingAddress";
 import { Country } from "../models/system/country/Country";
-import { User } from "../models/system/user/User";
 import { Currency } from "../models/system/currency/Currency";
+import { Customer } from "../models/checkout/customer/Customer";
 
 export interface ContextTokenResponse {
   contextToken: string;
@@ -29,7 +29,7 @@ export interface SessionContext {
     id: string;
     name: string;
   }[];
-  customer?: User;
+  customer: null | Customer;
   paymentMethod: PaymentMethod;
   shippingMethod: ShippingMethod;
   shippingLocation: {

--- a/packages/composables/__tests__/useCheckout.spec.ts
+++ b/packages/composables/__tests__/useCheckout.spec.ts
@@ -117,7 +117,7 @@ describe("Composables - useCheckout", () => {
         isLoggedIn.value = true;
         sessionContextMock.value = {
           customer: {
-            activeBillingAddress: {
+            defaultBillingAddress: {
               street: "some street",
             },
           },

--- a/packages/composables/__tests__/useCustomerOrders.spec.ts
+++ b/packages/composables/__tests__/useCustomerOrders.spec.ts
@@ -42,7 +42,7 @@ describe("Composables - useCustomerOrders", () => {
               id: "12345",
               orderNumber: "100123",
             },
-          ]
+          ],
         };
         mockedApiClient.getCustomerOrders.mockResolvedValueOnce(
           ordersResponse as any
@@ -77,7 +77,7 @@ describe("Composables - useCustomerOrders", () => {
 
       it("should return 0 when there is no orders", () => {
         const ordersResponse = {
-          elements: []
+          elements: [],
         };
         mockedApiClient.getCustomerOrders.mockResolvedValueOnce(
           ordersResponse as any
@@ -86,29 +86,29 @@ describe("Composables - useCustomerOrders", () => {
 
         expect(getTotal.value).toEqual(0);
       });
-  
+
       it("should return total same value with count field", async () => {
         const ordersResponse = {
           aggregations: {
-            'count-id': {
-              count: 20
-            }
+            "count-id": {
+              count: 20,
+            },
           },
           elements: Array(20).fill({
             id: "11111",
             orderNumber: "100120",
-          })
+          }),
         };
         mockedApiClient.getCustomerOrders.mockResolvedValueOnce(
           ordersResponse as any
         );
-        
+
         const { getTotal, loadOrders } = useCustomerOrders();
         await loadOrders();
         expect(getTotal.value).toEqual(20);
       });
     });
-  
+
     describe("getLimit", () => {
       it("should return 10 when there is no configuration set", async () => {
         const ordersResponse = {
@@ -127,7 +127,7 @@ describe("Composables - useCustomerOrders", () => {
         await loadOrders();
         expect(getLimit.value).toEqual(10);
       });
-  
+
       it("should return limit from current orders", async () => {
         const ordersResponse = {
           elements: [
@@ -136,7 +136,7 @@ describe("Composables - useCustomerOrders", () => {
               orderNumber: "100123",
             },
           ],
-          limit: 11
+          limit: 11,
         };
         mockedApiClient.getCustomerOrders.mockResolvedValueOnce(
           ordersResponse as any
@@ -146,42 +146,42 @@ describe("Composables - useCustomerOrders", () => {
         expect(getLimit.value).toEqual(11);
       });
     });
-  
+
     describe("getTotalPagesCount", () => {
       it("should return 0 when there is no currentListing", async () => {
         const ordersResponse = {
           aggregations: {
-            'count-id': {
-              count: 0
-            }
+            "count-id": {
+              count: 0,
+            },
           },
-          elements: []
+          elements: [],
         };
         mockedApiClient.getCustomerOrders.mockResolvedValueOnce(
           ordersResponse as any
         );
-        
+
         const { getTotalPagesCount, loadOrders } = useCustomerOrders();
         await loadOrders();
         expect(getTotalPagesCount.value).toEqual(0);
       });
-  
+
       it("should return ceiled pages count from current listing", async () => {
         const ordersResponse = {
           aggregations: {
-            'count-id': {
-              count: 22
-            }
+            "count-id": {
+              count: 22,
+            },
           },
           elements: Array(22).fill({
             id: "11111",
             orderNumber: "100120",
-          })
+          }),
         };
         mockedApiClient.getCustomerOrders.mockResolvedValueOnce(
           ordersResponse as any
         );
-        
+
         const { getTotalPagesCount, loadOrders } = useCustomerOrders();
         await loadOrders();
         expect(getTotalPagesCount.value).toEqual(3);
@@ -197,27 +197,27 @@ describe("Composables - useCustomerOrders", () => {
       it("should return 1 when there is no orders", async () => {
         const ordersResponse = {
           aggregations: {
-            'count-id': {
-              count: 0
-            }
+            "count-id": {
+              count: 0,
+            },
           },
-          elements: []
+          elements: [],
         };
         mockedApiClient.getCustomerOrders.mockResolvedValueOnce(
           ordersResponse as any
         );
-        
+
         const { getCurrentPage, loadOrders } = useCustomerOrders();
         await loadOrders();
         expect(getCurrentPage.value).toEqual(1);
       });
-  
+
       it("should return page number from current listing", async () => {
         const ordersResponse = {
           aggregations: {
-            'count-id': {
-              count: 3
-            }
+            "count-id": {
+              count: 3,
+            },
           },
           page: 3,
           limit: 1,
@@ -229,32 +229,36 @@ describe("Composables - useCustomerOrders", () => {
             {
               id: "12346",
               orderNumber: "100123",
-            }
-          ]
+            },
+          ],
         };
         mockedApiClient.getCustomerOrders.mockResolvedValueOnce(
           ordersResponse as any
         );
-        
+
         const { getCurrentPage, loadOrders } = useCustomerOrders();
         await loadOrders();
         expect(getCurrentPage.value).toEqual(3);
       });
     });
-  
+
     describe("changeCurrentPage", () => {
       it("should invoke search with changed page number", async () => {
-        const ordersResponse = (page: number) : EntityResult<"order", Order[]> => ({
+        const ordersResponse = (
+          page: number
+        ): EntityResult<"order", Order[]> => ({
           aggregations: [],
           page,
           limit: 10,
-          entity: 'order',
+          entity: "order",
           total: 10,
-          apiAlias: '',
-          elements: []
+          apiAlias: "",
+          elements: [],
         });
-        mockedApiClient.getCustomerOrders.mockImplementationOnce(async (params) => Promise.resolve(ordersResponse(params?.page || 1)));
-        
+        mockedApiClient.getCustomerOrders.mockImplementationOnce(
+          async (params) => Promise.resolve(ordersResponse(params?.page || 1))
+        );
+
         const { changeCurrentPage, getCurrentPage } = useCustomerOrders();
         await changeCurrentPage(3);
         expect(getCurrentPage.value).toEqual(3);

--- a/packages/composables/__tests__/useProductReviews.spec.ts
+++ b/packages/composables/__tests__/useProductReviews.spec.ts
@@ -37,62 +37,66 @@ describe("Composables - useProductReviews", () => {
   describe("methods", () => {
     describe("loadProductReviews", () => {
       it("should load be empty array when product dont have any review", async () => {
-        const product: any = { id: '1' };
+        const product: any = { id: "1" };
 
         const reviewsResponse = {
-          elements: null
+          elements: null,
         };
         mockedApiClient.getProductReviews.mockResolvedValueOnce(
           reviewsResponse as any
         );
-    
-        const { productReviews, loadProductReviews } = useProductReviews({ product });
+
+        const { productReviews, loadProductReviews } = useProductReviews({
+          product,
+        });
         expect(productReviews.value).toBeNull();
         await loadProductReviews();
         expect(productReviews.value).toEqual([]);
       });
 
       it("should load product reviews from different endpoint", async () => {
-        const product: any = { id: '1' };
+        const product: any = { id: "1" };
 
         const reviewsResponse = {
           elements: [
             {
               id: "421dd57b2a104837b25c7062b2edc597",
               content: "test content test content test content",
-              externalUser: '1',
-              customerId: '1',
+              externalUser: "1",
+              customerId: "1",
               title: "test review function",
               createdAt: "2022-06-10T07:04:21.693+00:00",
-              points: 5
+              points: 5,
             },
             {
               id: "421dd57b2a104837b25c7062b2edc597",
               content: "test content test content test content",
-              customerId: '1',
+              customerId: "1",
               title: "test review function",
               createdAt: "2022-06-10T07:04:21.693+00:00",
-              points: 5
+              points: 5,
             },
-          ]
+          ],
         };
         mockedApiClient.getProductReviews.mockResolvedValueOnce(
           reviewsResponse as any
         );
-    
-        const { productReviews, loadProductReviews } = useProductReviews({ product });
+
+        const { productReviews, loadProductReviews } = useProductReviews({
+          product,
+        });
         expect(productReviews.value).toBeNull();
         await loadProductReviews();
         expect(productReviews.value).toHaveLength(2);
       });
 
       it("should be show errors when fetching api was failed", async () => {
-        const product: any = { id: '1' };
-       
+        const product: any = { id: "1" };
+
         mockedApiClient.getProductReviews.mockRejectedValueOnce({
           messages: [{ detail: "Network Error" }],
         } as ClientApiError);
-    
+
         const { errors, loadProductReviews } = useProductReviews({ product });
         await loadProductReviews();
         expect(errors.loadProductReviews).toEqual([
@@ -103,36 +107,38 @@ describe("Composables - useProductReviews", () => {
 
     describe("addReview", () => {
       it("should be success when calling api successfully", async () => {
-        const product: any = { id: '1' };
-       
+        const product: any = { id: "1" };
+
         mockedApiClient.addProductReview.mockResolvedValueOnce({} as any);
-    
-        const { isSendingReview, wasReviewSent, addReview } = useProductReviews({ product });
+
+        const { isSendingReview, wasReviewSent, addReview } = useProductReviews(
+          { product }
+        );
         expect(wasReviewSent.value).toBeFalsy();
         expect(isSendingReview.value).toBeFalsy();
         await addReview({
-          title: 'title',
-          content: 'content',
+          title: "title",
+          content: "content",
           points: 5,
-        })
+        });
         expect(wasReviewSent.value).toBeTruthy();
         expect(isSendingReview.value).toBeFalsy();
       });
       it("should return errors when calling api got trouble", async () => {
-        const product: any = { id: '1' };
-       
+        const product: any = { id: "1" };
+
         mockedApiClient.addProductReview.mockRejectedValueOnce({
           messages: [{ detail: "This value is too short" }],
         } as ClientApiError);
-    
+
         const { errors, addReview } = useProductReviews({ product });
         await addReview({
-          title: 'title',
-          content: 'content',
+          title: "title",
+          content: "content",
           points: 5,
-        })
+        });
         expect(errors.addReview).toEqual([
-          { detail: "This value is too short" }
+          { detail: "This value is too short" },
         ]);
       });
     });

--- a/packages/composables/__tests__/useSessionContext.spec.ts
+++ b/packages/composables/__tests__/useSessionContext.spec.ts
@@ -130,7 +130,7 @@ describe("Composables - useSessionContext", () => {
       it("should return activeBillingAddress from context", () => {
         stateContext.value = {
           customer: {
-            activeBillingAddress: {
+            defaultBillingAddress: {
               id: "address-billing-id",
             },
           },
@@ -156,8 +156,8 @@ describe("Composables - useSessionContext", () => {
     describe("activeShippingAddress", () => {
       it("should return activeShippingAddress from context", () => {
         stateContext.value = {
-          customer: {
-            activeShippingAddress: {
+          shippingLocation: {
+            address: {
               id: "address-shipping-id",
             },
           },

--- a/packages/composables/src/hooks/useCustomerOrders.ts
+++ b/packages/composables/src/hooks/useCustomerOrders.ts
@@ -63,7 +63,7 @@ export function useCustomerOrders(): IUseCustomerOrders {
   const getTotal = computed(() => {
     /** We will update the new way to get total after BE add it into response api */
     const aggregations: any = ordersResult.value?.aggregations;
-    return aggregations?.['count-id']?.count || 0;
+    return aggregations?.["count-id"]?.count || 0;
   });
 
   const getLimit = computed(() => {
@@ -74,9 +74,7 @@ export function useCustomerOrders(): IUseCustomerOrders {
     Math.ceil(getTotal.value / getLimit.value)
   );
 
-  const orders = computed(() =>
-    ordersResult.value?.elements || []
-  );
+  const orders = computed(() => ordersResult.value?.elements || []);
 
   const getCurrentPage = computed(() => ordersResult.value?.page || 1);
   const changeCurrentPage = async (pageNumber: number | string) => {

--- a/packages/composables/src/internalHelpers/defaultApiParams.json
+++ b/packages/composables/src/internalHelpers/defaultApiParams.json
@@ -238,8 +238,7 @@
   },
   "useNavigation": {
     "associations": {
-      "media": {},
-      "seoUrls": {}
+      "media": {}
     },
     "includes": {
       "category": [

--- a/packages/composables/src/logic/useCheckout.ts
+++ b/packages/composables/src/logic/useCheckout.ts
@@ -127,7 +127,7 @@ export function useCheckout(): IUseCheckout {
     () => sessionContext.value?.shippingLocation?.address
   );
   const billingAddress = computed(
-    () => sessionContext.value?.customer?.activeBillingAddress
+    () => sessionContext.value?.customer?.defaultBillingAddress
   );
 
   return {

--- a/packages/composables/src/logic/useProductReviews.ts
+++ b/packages/composables/src/logic/useProductReviews.ts
@@ -1,7 +1,7 @@
 import { ref, Ref, UnwrapRef, reactive, unref } from "vue-demi";
 import {
   getProductReviews,
-  addProductReview
+  addProductReview,
 } from "@shopware-pwa/shopware-6-client";
 import {
   Product,
@@ -57,7 +57,7 @@ export function useProductReviews(params: {
     addReview: ShopwareError[];
   }> = reactive({
     loadProductReviews: [],
-    addReview: []
+    addReview: [],
   });
   const productReviews: Ref<UiProductReview[] | null> = ref(null);
 
@@ -70,16 +70,24 @@ export function useProductReviews(params: {
         Object.assign({}, getDefaults(), parameters),
         apiInstance
       );
-      productReviews.value = fetchedReviews.elements?.map(
-        ({ id, externalUser, customerId, createdAt, content, points }: ProductReview) => ({
-          id,
-          author: externalUser ? externalUser : customerId,
-          date: createdAt,
-          message: content,
-          rating: points,
-        })
-      ) ?? [];
-    } catch(e) {
+      productReviews.value =
+        fetchedReviews.elements?.map(
+          ({
+            id,
+            externalUser,
+            customerId,
+            createdAt,
+            content,
+            points,
+          }: ProductReview) => ({
+            id,
+            author: externalUser ? externalUser : customerId,
+            date: createdAt,
+            message: content,
+            rating: points,
+          })
+        ) ?? [];
+    } catch (e) {
       const err: ClientApiError = e;
       errors.loadProductReviews = err.messages;
     }
@@ -92,18 +100,14 @@ export function useProductReviews(params: {
   }) => {
     isSendingReview.value = true;
     try {
-      await addProductReview(
-        product.id,
-        data,
-        apiInstance
-      );
+      await addProductReview(product.id, data, apiInstance);
       wasReviewSent.value = true;
     } catch (error) {
       console.error("[SwAddProductReview][submitForm]: ", error);
       errors.addReview = error.messages;
     }
     isSendingReview.value = false;
-  }
+  };
 
   return {
     productReviews,

--- a/packages/composables/src/logic/useSessionContext.ts
+++ b/packages/composables/src/logic/useSessionContext.ts
@@ -144,7 +144,7 @@ export function useSessionContext(): IUseSessionContext {
   };
 
   const activeShippingAddress = computed(
-    () => sessionContext.value?.customer?.activeShippingAddress || null
+    () => sessionContext.value?.shippingLocation?.address || null
   );
   const setActiveShippingAddress = async (
     address: Partial<ShippingAddress>
@@ -159,7 +159,7 @@ export function useSessionContext(): IUseSessionContext {
   };
 
   const activeBillingAddress = computed(
-    () => sessionContext.value?.customer?.activeBillingAddress || null
+    () => sessionContext.value?.customer?.defaultBillingAddress || null
   );
   const setActiveBillingAddress = async (address: Partial<BillingAddress>) => {
     if (!address?.id) {

--- a/packages/default-theme/src/components/SwProductListingFilters.vue
+++ b/packages/default-theme/src/components/SwProductListingFilters.vue
@@ -140,7 +140,7 @@ export default {
       getSortingOrders,
       getAvailableFilters,
       getCurrentListing,
-      search,
+      search: listingSearch,
       getCurrentFilters,
       getTotal,
     } = useListing({ listingType: props.listingType })
@@ -164,6 +164,15 @@ export default {
       get: () => getCurrentSortingOrder.value,
       set: (order) => changeCurrentSortingOrder(order),
     })
+
+    const search = () => {
+      listingSearch({
+        ...sidebarSelectedFilters.value,
+        manufacturer: sidebarSelectedFilters.value.manufacturer?.join("|"),
+        properties: sidebarSelectedFilters.value.properties?.join("|")
+      })
+    }
+
 
     return {
       search,
@@ -192,7 +201,6 @@ export default {
         this.sidebarSelectedFilters,
         filter
       )
-
       this.search(this.sidebarSelectedFilters)
     },
     async clearAllFilters() {

--- a/packages/default-theme/src/components/checkout/CheckoutSummary.vue
+++ b/packages/default-theme/src/components/checkout/CheckoutSummary.vue
@@ -30,10 +30,8 @@ import ShippingSection from "@/components/checkout/ShippingSection.vue"
 import PaymentSection from "@/components/checkout/PaymentSection.vue"
 import SwAddressManager from "@/components/forms/SwAddressManager.vue"
 import {
-  useCart,
   useCustomerAddresses,
   useSessionContext,
-  useUser,
 } from "@shopware-pwa/composables"
 
 export default {
@@ -84,8 +82,6 @@ export default {
       addedActiveBillingAddress,
     }
   },
-
-
 }
 </script>
 <style lang="scss" scoped>

--- a/packages/default-theme/src/components/checkout/CheckoutSummary.vue
+++ b/packages/default-theme/src/components/checkout/CheckoutSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="sw-checkout-summary">
-    <div class="sw-checkout-summary__addresses">
+    <div class="sw-checkout-summary__addresses" v-if="activeShippingAddress">
       <SwAddressManager
         :title-text="$t('Shipping address')"
         class="sw-checkout-summary__addresses-wrapper"
@@ -24,6 +24,7 @@
 </template>
 
 <script>
+import { onMounted } from "@vue/composition-api"
 import PaymentMethodSummary from "@/components/checkout/summary/PaymentMethodSummary.vue"
 import ShippingSection from "@/components/checkout/ShippingSection.vue"
 import PaymentSection from "@/components/checkout/PaymentSection.vue"
@@ -44,8 +45,11 @@ export default {
     SwAddressManager,
   },
   setup() {
-    const { addresses, loadAddresses } = useCustomerAddresses()
-    loadAddresses()
+    const { addresses, loadAddresses } = useCustomerAddresses();
+
+    onMounted(() => {
+      loadAddresses();
+    });
 
     const {
       activeShippingAddress,
@@ -80,20 +84,8 @@ export default {
       addedActiveBillingAddress,
     }
   },
-  computed: {
-    shipping() {
-      return {} // this.order.shipping
-    },
-    shippingMethod() {
-      return { label: "" }
-    },
-    payment() {
-      return {} // this.order.payment
-    },
-    paymentMethod() {
-      return { label: "" }
-    },
-  },
+
+
 }
 </script>
 <style lang="scss" scoped>

--- a/packages/shopware-6-client/__tests__/services/CustomerService/getCustomerOrders.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/CustomerService/getCustomerOrders.spec.ts
@@ -44,14 +44,14 @@ describe("CustomerService - getCustomerOrders", () => {
     expect(mockedPost).toBeCalledTimes(1);
     expect(mockedPost).toBeCalledWith("/store-api/order", {});
     expect(result).toMatchObject({
-      "elements" :[
+      elements: [
         {
           orderNumber: "1234",
         },
         {
           orderNumber: "4321",
         },
-      ]
+      ],
     });
   });
 });

--- a/packages/shopware-6-client/__tests__/services/FormService/newsletterUnubscribe.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/FormService/newsletterUnubscribe.spec.ts
@@ -17,15 +17,16 @@ describe("FormService - newsletterUnsubscribe", () => {
   it("should invoke correct API endpoint with given parameters", async () => {
     await newsletterUnsubscribe({ email: "john@doe.com" });
     expect(mockedPost).toBeCalledTimes(1);
-    expect(mockedPost).toBeCalledWith(
-      "/store-api/newsletter/unsubscribe",
-      {"email": "john@doe.com"}
-    );
+    expect(mockedPost).toBeCalledWith("/store-api/newsletter/unsubscribe", {
+      email: "john@doe.com",
+    });
   });
 
   it("should throw an error when data is incorrect", async () => {
     mockedPost.mockRejectedValueOnce(new Error("500"));
     expect(newsletterUnsubscribe({ email: "" })).rejects.toThrowError("500");
-    expect(mockedPost).toBeCalledWith("/store-api/newsletter/unsubscribe", {"email": ""});
+    expect(mockedPost).toBeCalledWith("/store-api/newsletter/unsubscribe", {
+      email: "",
+    });
   });
 });

--- a/packages/shopware-6-client/src/endpoints.ts
+++ b/packages/shopware-6-client/src/endpoints.ts
@@ -308,4 +308,4 @@ export const getMergeWishlistProductsEndpoint = () =>
 /**
  * @public
  */
-export const getCustomerDeleteEndpoint = () => `/store-api/account/customer`
+export const getCustomerDeleteEndpoint = () => `/store-api/account/customer`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4926,15 +4926,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001286:
-  version "1.0.30001297"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001297.tgz#ea7776ccc4992956582cae5b8fea127fbebde430"
-  integrity sha512-6bbIbowYG8vFs/Lk4hU9jFt7NknGDleVAciK916tp6ft1j+D//ZwwL6LbF1wXMQ32DMSjeuUV8suhh6dlmFjcA==
-
-caniuse-lite@^1.0.30001332:
-  version "1.0.30001344"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz#8a1e7fdc4db9c2ec79a05e9fd68eb93a761888bb"
-  integrity sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001332:
+  version "1.0.30001488"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz"
+  integrity sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
## Changes

closes: #1992 

### removed fields from API response:
- activeBillingAddress
- activeShippingAddress

the fields were replacement by another sources.

### association seoUrls not supported

for `/navigation` endpoint `seoUrls` association is not necessary anymore. the `sw-include-seo-urls` header does the job.


<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [ ] the [list of features](https://github.com/vuestorefront/shopware-pwa/blob/master/docs/landing/resources/features.md) is updated (if it's a feature and it's relevant)
- [ ] I followed [contributing](https://github.com/vuestorefront/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
