### PR TITLE
fix: supporting context-token header return

### DIFF
--- a/packages/shopware-6-client/__tests__/services/CustomerService/login.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/CustomerService/login.spec.ts
@@ -22,7 +22,7 @@ describe("CustomerService - login", () => {
     } as any;
   });
   it("should invoke a POST request with given parameters", async () => {
-    mockedPost.mockResolvedValueOnce({ data: {} } as any);
+    mockedPost.mockResolvedValueOnce({ data: {}, headers: {} } as any);
 
     await login(undefined);
     expect(mockedPost).toBeCalledTimes(1);
@@ -34,6 +34,7 @@ describe("CustomerService - login", () => {
   it("should return context token in new format if old does not exist", async () => {
     mockedPost.mockResolvedValueOnce({
       data: { contextToken: "RmzTExFStSBW5GhPmQNicSK6bhUQhqXi" },
+      headers: {}
     });
 
     const result = await login({
@@ -47,6 +48,26 @@ describe("CustomerService - login", () => {
     });
 
     expect(result.contextToken).toEqual("RmzTExFStSBW5GhPmQNicSK6bhUQhqXi");
+  });
+  it("should return context token from the header if it's missing in JSON response", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {},
+      headers: {
+        "sw-context-token": "AmzTExFStSBW5GhPmQNicSK6bhUQhqXz"
+      }
+    });
+
+    const result = await login({
+      username: credentials.username,
+      password: credentials.password,
+    });
+    expect(mockedPost).toBeCalledTimes(1);
+    expect(mockedPost).toBeCalledWith(getCustomerLoginEndpoint(), {
+      username: credentials.username,
+      password: credentials.password,
+    });
+
+    expect(result.contextToken).toEqual("AmzTExFStSBW5GhPmQNicSK6bhUQhqXz");
   });
   it("should return context token", async () => {
     mockedPost.mockResolvedValueOnce({

--- a/packages/shopware-6-client/src/services/customerService.ts
+++ b/packages/shopware-6-client/src/services/customerService.ts
@@ -68,7 +68,7 @@ export async function login(
     password,
   });
   const contextToken =
-    resp.data["sw-context-token"] || resp.data["contextToken"] || resp.headers?.["sw-context-token"];
+    resp.data["sw-context-token"] || resp.data["contextToken"] || resp.headers["sw-context-token"];
   return { contextToken };
 }
 

--- a/packages/shopware-6-client/src/services/customerService.ts
+++ b/packages/shopware-6-client/src/services/customerService.ts
@@ -68,7 +68,7 @@ export async function login(
     password,
   });
   const contextToken =
-    resp.data["sw-context-token"] || resp.data["contextToken"];
+    resp.data["sw-context-token"] || resp.data["contextToken"] || resp.headers?.["sw-context-token"];
   return { contextToken };
 }
 


### PR DESCRIPTION
Shopware 6.6 removed contextToken from the JSON response in login/logout calls. It is now necessary to pull the context token from the Headers.

## Changes

closes [#2013](https://github.com/vuestorefront/shopware-pwa/issues/2013)

### Checklist

- [x] the [list of features](https://github.com/vuestorefront/shopware-pwa/blob/master/docs/landing/resources/features.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/vuestorefront/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines

---
I am not quite sure how to handle this kind of ticket. It is a feature or a bug, maybe some things are forgotten. Would love feedback on this.